### PR TITLE
taskgraph 09d4c6dec78d17beb186eef1f79c1ab712ccc433

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -7,7 +7,7 @@ tasks:
     - $let:
           taskgraph:
               branch: taskgraph
-              revision: d302e95cc988706ba746bfecbf1dae31090d212f
+              revision: 09d4c6dec78d17beb186eef1f79c1ab712ccc433
           trustDomain: xpi
       in:
           $if: 'tasks_for in ["github-pull-request", "github-push", "action", "cron"]'


### PR DESCRIPTION
This should fix the scopes issue going forward. The hash refers to the [latest commit in taskgraph](https://hg.mozilla.org/ci/taskgraph).