### PR TITLE
also fix caches

### DIFF
--- a/taskcluster/ci/build/kind.yml
+++ b/taskcluster/ci/build/kind.yml
@@ -23,6 +23,8 @@ job-defaults:
 
 jobs:
     ci:
+        attributes:
+            code-review: true
         run:
             using: run-task
             cwd: '{checkout}'

--- a/taskcluster/ci/build/kind.yml
+++ b/taskcluster/ci/build/kind.yml
@@ -17,7 +17,7 @@ job-defaults:
     worker:
         max-run-time: 7200
         docker-image:
-            indexed: xpi.xpi-manifest.cache.level-1.docker-images.v2.node-latest.latest
+            indexed: xpi.cache.level-1.docker-images.v2.node-latest.latest
     run:
         use-caches: false
 

--- a/taskcluster/ci/test/kind.yml
+++ b/taskcluster/ci/test/kind.yml
@@ -23,6 +23,8 @@ job-defaults:
 
 jobs:
     ci:
+        attributes:
+            code-review: true
         run:
             using: run-task
             cwd: '{checkout}'

--- a/taskcluster/ci/test/kind.yml
+++ b/taskcluster/ci/test/kind.yml
@@ -17,7 +17,7 @@ job-defaults:
     worker:
         max-run-time: 7200
         docker-image:
-            indexed: xpi.xpi-manifest.cache.level-1.docker-images.v2.node-latest.latest
+            indexed: xpi.cache.level-1.docker-images.v2.node-latest.latest
     run:
         use-caches: false
 


### PR DESCRIPTION
This should fix the scopes issue going forward. The hash refers to the [latest commit in taskgraph](https://hg.mozilla.org/ci/taskgraph).

This also fixes caches, as per https://github.com/mozilla-extensions/xpi-manifest/pull/5