### PR TITLE
Configure web-ext to set needed prefs

### DIFF
--- a/web-ext-config.js
+++ b/web-ext-config.js
@@ -1,0 +1,11 @@
+/* eslint-env node */
+
+module.exports = {
+  run: {
+    browserConsole: true,
+    pref: [
+      "extensions.legacy.enabled=true",
+      "extensions.experiments.enabled=true",
+    ],
+  },
+};


### PR DESCRIPTION
With recent changes to Firefox, we now need to set `extensions.experiments.enabled=true` in order to use web-ext to test the add-on. This configuration file automates that, as well as automatically opening the browser console, which can be quite useful.