### PR TITLE
 Load filter context dynamically instead of with a static list 

### DIFF
--- a/extension/content/components/common/DataTree.js
+++ b/extension/content/components/common/DataTree.js
@@ -10,6 +10,11 @@ export default class DataTree extends React.PureComponent {
     data: PropTypes.object,
     onDoubleClick: PropTypes.func,
     title: PropTypes.string,
+    defaultExpanded: PropTypes.bool,
+  };
+
+  static defaultProps = {
+    defaultExpanded: true,
   };
 
   getSwitcherIcon(obj) {
@@ -27,11 +32,11 @@ export default class DataTree extends React.PureComponent {
   }
 
   render() {
-    const { data, onDoubleClick, title } = this.props;
+    const { data, onDoubleClick, title, defaultExpanded } = this.props;
     if (data) {
       return (
         <Tree
-          defaultExpandedKeys={[title]}
+          defaultExpandedKeys={defaultExpanded ? [title] : []}
           switcherIcon={this.getSwitcherIcon}
           selectable={false}
           onDoubleClick={onDoubleClick}

--- a/extension/content/components/pages/FiltersPage.js
+++ b/extension/content/components/pages/FiltersPage.js
@@ -74,17 +74,28 @@ class FiltersPage extends React.PureComponent {
             <header>
               <strong>Client Context</strong>
             </header>
-            {!context.normandy && (
+            {!(context.normandy || context.env) && (
               <div className="text-center">
                 <Loader />
               </div>
             )}
-            <DataTree
-              data={context.normandy}
-              title="normandy"
-              key="normandy"
-              onDoubleClick={this.handleDoubleClickTreeNode}
-            />
+            {context.env && (
+              <DataTree
+                data={context.env}
+                title="env"
+                key="env"
+                onDoubleClick={this.handleDoubleClickTreeNode}
+                defaultExpanded={false}
+              />
+            )}
+            {context.normandy && (
+              <DataTree
+                data={context.normandy}
+                title="normandy"
+                key="normandy"
+                onDoubleClick={this.handleDoubleClickTreeNode}
+              />
+            )}
           </div>
         </div>
         <div className="col">

--- a/extension/experiments/normandy/api.js
+++ b/extension/experiments/normandy/api.js
@@ -4,6 +4,7 @@ ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");
 XPCOMUtils.defineLazyModuleGetters(this, {
   ActionsManager: "resource://normandy/lib/ActionsManager.jsm",
   AddonStudies: "resource://normandy/lib/AddonStudies.jsm",
+  ClientEnvironment: "resource://normandy/lib/ClientEnvironment.jsm",
   FilterExpressions:
     "resource://gre/modules/components-utils/FilterExpressions.jsm",
   PreferenceExperiments: "resource://normandy/lib/PreferenceExperiments.jsm",
@@ -43,37 +44,45 @@ var normandy = class extends ExtensionAPI {
             // context.normandy is a proxy object that can't be sent to the
             // webextension directly. Instead, manually copy relevant keys to a
             // simple object, and return that.
-            let builtContext = { normandy: {} };
-            const keysToCopy = [
-              "channel",
-              "distribution",
-              "doNotTrack",
-              "isDefaultBrowser",
-              "isFirstRun",
-              "locale",
-              "recipe",
-              "syncDesktopDevices",
-              "syncMobileDevices",
-              "syncSetup",
-              "syncTotalDevices",
-              "userId",
-              "version",
-            ];
-            const keysToAwait = [
-              "addons",
-              "country",
-              "experiments",
-              "os",
-              "plugins",
-              "request_time",
-              "searchEngine",
-              "telemetry",
-            ];
-            for (const key of keysToCopy) {
-              builtContext.normandy[key] = context.normandy[key];
+
+            let builtContext = { normandy: {}, env: {} };
+
+            // Walk up the class chain for ClientEnvironment, collecting
+            // applicable keys as we go. Stop when we get to an unnamed object,
+            // which is usually just a plain function is the super class of a
+            // class that doesn't extend anything. Also stop if we get to an
+            // undefined object, just in case.
+            let env = ClientEnvironment;
+            let keys = new Set();
+            while (env && env.name) {
+              for (const [name, descriptor] of Object.entries(
+                Object.getOwnPropertyDescriptors(env),
+              )) {
+                // All of the properties we are looking for are are static getters (so
+                // will have a truthy `get` property) and are defined on the class, so
+                // will be configurable
+                if (descriptor.configurable && descriptor.get) {
+                  keys.add(name);
+                }
+              }
+              // Check for the next parent
+              env = Object.getPrototypeOf(env);
             }
-            for (const key of keysToAwait) {
-              builtContext.normandy[key] = await context.normandy[key];
+
+            // it is generally safe to await values that aren't promises, just a bit inefficient
+            for (const key of keys) {
+              if (key == "liveTelemetry") {
+                // Live Telemetry is a weird proxy object. Unpack it.
+                builtContext.normandy.liveTelemetry = {
+                  main: await context.normandy.liveTelemetry.main,
+                };
+                builtContext.env.liveTelemetry = {
+                  main: await context.env.liveTelemetry.main,
+                };
+              } else {
+                builtContext.normandy[key] = await context.normandy[key];
+                builtContext.env[key] = await context.env[key];
+              }
             }
             return builtContext;
           },


### PR DESCRIPTION
This is more future proof, since it will automatically pick up normal attributes that get added to the filter context. The class walking code is derived from how Normandy Client [calculates the available properties of the context](https://searchfox.org/mozilla-central/rev/f98dad153b59a985efd4505912588d4651033395/toolkit/components/normandy/lib/RecipeRunner.jsm#422-446) for capability calculation.