### PR TITLE
Add ability to inject export button into Experimenter

### DIFF
--- a/extension/content/scripts/inject.js
+++ b/extension/content/scripts/inject.js
@@ -20,7 +20,7 @@ function injectImportLink(element, environment) {
   );
 }
 
-function injectRecipeDetailsLinks(element, environment) {
+function injectRecipeDetailsLink(element, environment) {
   const { environmentKey } = environment;
   element.setAttribute(
     "href",
@@ -43,7 +43,7 @@ if (document.body.dataset.ndt === "experimenter") {
         let injector;
         switch (el.dataset.ndtInject) {
           case "recipe-details-link":
-            injector = injectRecipeDetailsLinks;
+            injector = injectRecipeDetailsLink;
             break;
 
           case "import-link":

--- a/extension/content/scripts/inject.js
+++ b/extension/content/scripts/inject.js
@@ -1,0 +1,52 @@
+import { ENVIRONMENTS } from "devtools/config";
+
+// Re-map environments to experimenter URLs
+const experimenterUrls = {};
+Object.keys(ENVIRONMENTS).forEach((k) => {
+  const env = ENVIRONMENTS[k];
+  if (env.experimenterUrl) {
+    experimenterUrls[env.experimenterUrl] = {
+      ...env,
+      environmentKey: k,
+    };
+  }
+});
+
+const injectionSite = document.getElementById(
+  "ndt-export-button-injection-site",
+);
+
+// If an injection site exists we must be on Experimenter so attempt to inject the button
+if (injectionSite) {
+  Object.keys(experimenterUrls).forEach((url) => {
+    if (window.location.href.startsWith(url)) {
+      injectionSite.innerHTML = ""; // Make sure the injection site is clear
+
+      // Hide the existing export button
+      const oldButton = document.querySelector(
+        '[data-target="#normandyModal"]',
+      );
+      if (oldButton) {
+        oldButton.classList.add("d-none");
+      }
+
+      // Create the new button
+      const experimenterSlug = injectionSite.dataset.slug;
+      const { environmentKey } = experimenterUrls[url];
+      const exportButton = document.createElement("a");
+      exportButton.classList.add("col", "btn", "btn-primary", "mb-3");
+      exportButton.setAttribute("target", "_blank");
+      exportButton.setAttribute(
+        "href",
+        `ext+normandy://${environmentKey}/recipes/import/${experimenterSlug}`,
+      );
+      exportButton.textContent = "Export to Normandy";
+
+      const exportButtonIcon = document.createElement("span");
+      exportButtonIcon.classList.add("fas", "fa-file-import", "mr-2");
+      exportButton.prepend(exportButtonIcon);
+
+      injectionSite.appendChild(exportButton);
+    }
+  });
+}

--- a/extension/content/scripts/inject.js
+++ b/extension/content/scripts/inject.js
@@ -12,41 +12,48 @@ Object.keys(ENVIRONMENTS).forEach((k) => {
   }
 });
 
-const injectionSite = document.getElementById(
-  "ndt-export-button-injection-site",
-);
+function injectImportLink(element, environment) {
+  const { environmentKey } = environment;
+  element.setAttribute(
+    "href",
+    `ext+normandy://${environmentKey}/recipes/import/${element.dataset.slug}`,
+  );
+}
 
-// If an injection site exists we must be on Experimenter so attempt to inject the button
-if (injectionSite) {
+function injectRecipeDetailsLinks(element, environment) {
+  const { environmentKey } = environment;
+  element.setAttribute(
+    "href",
+    `ext+normandy://${environmentKey}/recipes/${element.dataset.recipeId}`,
+  );
+}
+
+if (document.body.dataset.ndt === "experimenter") {
+  document.querySelectorAll("[data-ndt-add-class]").forEach((el) => {
+    el.classList.add(el.dataset.ndtAddClass);
+  });
+
+  document.querySelectorAll("[data-ndt-remove-class]").forEach((el) => {
+    el.classList.remove(el.dataset.ndtRemoveClass);
+  });
+
   Object.keys(experimenterUrls).forEach((url) => {
     if (window.location.href.startsWith(url)) {
-      injectionSite.innerHTML = ""; // Make sure the injection site is clear
+      document.querySelectorAll("[data-ndt-inject]").forEach((el) => {
+        let injector;
+        switch (el.dataset.ndtInject) {
+          case "recipe-details-link":
+            injector = injectRecipeDetailsLinks;
+            break;
 
-      // Hide the existing export button
-      const oldButton = document.querySelector(
-        '[data-target="#normandyModal"]',
-      );
-      if (oldButton) {
-        oldButton.classList.add("d-none");
-      }
-
-      // Create the new button
-      const experimenterSlug = injectionSite.dataset.slug;
-      const { environmentKey } = experimenterUrls[url];
-      const exportButton = document.createElement("a");
-      exportButton.classList.add("col", "btn", "btn-primary", "mb-3");
-      exportButton.setAttribute("target", "_blank");
-      exportButton.setAttribute(
-        "href",
-        `ext+normandy://${environmentKey}/recipes/import/${experimenterSlug}`,
-      );
-      exportButton.textContent = "Export to Normandy";
-
-      const exportButtonIcon = document.createElement("span");
-      exportButtonIcon.classList.add("fas", "fa-file-import", "mr-2");
-      exportButton.prepend(exportButtonIcon);
-
-      injectionSite.appendChild(exportButton);
+          case "import-link":
+            injector = injectImportLink;
+            break;
+        }
+        if (injector) {
+          injector(el, experimenterUrls[url]);
+        }
+      });
     }
   });
 }

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -23,6 +23,17 @@
     "scripts": ["background.js"]
   },
 
+  "content_scripts": [
+    {
+      "matches": [
+        "http://*/*",
+        "https://*/*"
+      ],
+      "run_at": "document_end",
+      "js": ["content-scripts.js"]
+    }
+  ],
+
   "browser_action": {
     "default_title": "Normandy Devtools",
     "browser_style": true,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -15,6 +15,7 @@ module.exports = {
   devtool: "source-map",
   entry: {
     content: "./extension/content/index.js",
+    "content-scripts": "./extension/content/scripts/inject.js",
     redirect: "./extension/content/redirect.js",
     "dark-theme": "./extension/content/less/dark.less",
     "light-theme": "./extension/content/less/light.less",
@@ -42,7 +43,6 @@ module.exports = {
       favicon: path.resolve(__dirname, "extension/images/favicon.png"),
       filename: "content.html",
       chunks: ["content"],
-      excludeChunks: ["dark-theme", "light-theme"],
     }),
     new HtmlWebpackPlugin({
       title: "Redirect",


### PR DESCRIPTION
Fixes #43 
Fixes #82 

![Screenshot from 2020-04-09 01-17-27](https://user-images.githubusercontent.com/987136/78860714-e0e64f00-7a00-11ea-8737-304570c29170.png)

Requires the relevant patch on Experimenter to land:
~https://github.com/mozilla/experimenter/pull/2537~
https://github.com/mozilla/experimenter/pull/2542

r?