### PR TITLE
Fix styling of the arbitrary recipe editor

### DIFF
--- a/extension/content/components/common/CodeMirror.js
+++ b/extension/content/components/common/CodeMirror.js
@@ -15,6 +15,9 @@ const CodeMirror = React.forwardRef((props, ref) => {
       options={{
         mode: "json",
         theme: "ndt",
+        indentWithTabs: false,
+        indentUnit: 2,
+        tabSize: 2,
         ...options,
       }}
       {...cmProps}

--- a/extension/content/components/pages/RecipesPage.js
+++ b/extension/content/components/pages/RecipesPage.js
@@ -3,8 +3,6 @@ import PropTypes from "prop-types";
 import React from "react";
 import { Link } from "react-router-dom";
 
-import { Controlled as CodeMirror } from "react-codemirror2";
-import Highlight from "devtools/components/common/Highlight";
 import {
   Button,
   Header,
@@ -16,6 +14,8 @@ import {
   Pagination,
 } from "rsuite";
 
+import CodeMirror from "devtools/components/common/CodeMirror";
+import Highlight from "devtools/components/common/Highlight";
 import RecipeListing from "devtools/components/recipes/RecipeListing";
 import {
   useEnvironments,
@@ -115,7 +115,7 @@ class RecipesPage extends React.PureComponent {
     const { environmentKey } = this.props;
     const v1Recipe = convertToV1Recipe(v3Recipe, environmentKey);
     this.setState({
-      arbitraryRecipe: JSON.stringify(v1Recipe, null, 4),
+      arbitraryRecipe: JSON.stringify(v1Recipe, null, 2),
       showWriteRecipes: true,
     });
   }
@@ -217,14 +217,9 @@ class RecipesPage extends React.PureComponent {
           <CodeMirror
             options={{
               mode: "javascript",
-              theme: "neo",
               lineNumbers: true,
-              styleActiveLine: true,
             }}
             value={arbitraryRecipe}
-            style={{
-              height: "auto",
-            }}
             onBeforeChange={this.handleArbitraryRecipeChange}
           />
         </Modal.Body>

--- a/extension/content/less/cm-ndt.less
+++ b/extension/content/less/cm-ndt.less
@@ -6,6 +6,7 @@
     --cm-border: @input-border;
     --cm-border-focus: @input-border-focus;
     --cm-color: @text-color;
+    --cm-line-number-color: fade(#000, 40%);
     --cm-color-comment: @color-protocol-light-gray-70;
     --cm-color-blue: @color-protocol-blue-40;
     --cm-color-violet: @color-protocol-purple-60;
@@ -23,6 +24,7 @@
     --cm-border: @input-border;
     --cm-border-focus: @input-border-focus;
     --cm-color: @text-color;
+    --cm-line-number-color: fade(#FFF, 40%);
     --cm-color-comment: @color-protocol-light-gray-70;
     --cm-color-blue: @color-protocol-blue-40;
     --cm-color-violet: @color-protocol-purple-50;
@@ -84,14 +86,14 @@
   /* Editor styling */
 
   .CodeMirror-gutters {
-    background-color: transparent;
-    border: none;
-    border-right: 10px solid transparent;
+    background-color: var(--cm-border);
+    border-color: var(--cm-border);
+    white-space: nowrap;
   }
 
   .CodeMirror-linenumber {
-    color: var(--cm-color-gray);
-    padding: 0;
+    color: var(--cm-line-number-color);
+    padding: 0 3px 0 5px;
   }
 
   .CodeMirror-guttermarker {


### PR DESCRIPTION
Makes the arbitrary editor use the new common CodeMirror component and fixes the indent level.

Also better styling for the gutters/line numbers in the theme.

r?