### PR TITLE
Speed up webpack by using a faster devtool and caching more

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules/
 web-ext-artifacts/
 yarn-error.log
 .env
+.webpack-cache

--- a/package.json
+++ b/package.json
@@ -9,9 +9,9 @@
     "build": "npm-run-all clean build:webpack build:extension build:finalize",
     "build:extension": "web-ext build -s dist --overwrite-dest",
     "build:webpack": "webpack --mode production --progress",
-    "build:webpack-dev": "webpack --mode development --progress",
+    "build:webpack-dev": "webpack --mode development --progress --hide-modules",
     "build:finalize": "mv web-ext-artifacts/*.zip web-ext-artifacts/normandy-devtools.zip",
-    "clean": "rimraf dist web-ext-artifacts",
+    "clean": "rimraf dist web-ext-artifacts .webpack-cache",
     "lint": "npm-run-all lint:eslint",
     "lint-fix": "npm-run-all lint:eslint-fix",
     "lint:eslint": "eslint webpack.config.js extension",
@@ -19,7 +19,8 @@
     "test": "jest",
     "watch": "npm-run-all build:webpack-dev --parallel --race watch:*",
     "watch:extension": "web-ext run -s dist -f nightly",
-    "watch:webpack": "webpack --progress --mode development --watch"
+    "watch:webpack": "webpack --progress --mode development --watch",
+    "postinstall": "yarn clean"
   },
   "devDependencies": {
     "@babel/core": "7.9.0",
@@ -72,6 +73,7 @@
   "dependencies": {
     "auth0-js": "9.13.2",
     "autobind-decorator": "2.4.0",
+    "cache-loader": "^4.1.0",
     "codemirror": "5.53.2",
     "highlight.js": "10.0.0",
     "js-yaml": "3.13.1",

--- a/web-ext-config.js
+++ b/web-ext-config.js
@@ -2,7 +2,6 @@
 
 module.exports = {
   run: {
-    browserConsole: true,
     pref: [
       "extensions.legacy.enabled=true",
       "extensions.experiments.enabled=true",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -10,9 +10,14 @@ const FixStyleOnlyEntriesPlugin = require("webpack-fix-style-only-entries");
 const packageData = require("./package.json");
 const manifest = require("./extension/manifest.json");
 
-module.exports = {
-  mode: "development",
-  devtool: "source-map",
+const cacheLoader = {
+  loader: "cache-loader",
+  options: { cacheDirectory: ".webpack-cache" },
+};
+
+module.exports = (env, argv) => ({
+  mode: argv.mode || "development",
+  devtool: argv.mode == "production" ? "source-map" : "eval-source-map",
   entry: {
     content: "./extension/content/index.js",
     "content-scripts": "./extension/content/scripts/inject.js",
@@ -68,11 +73,12 @@ module.exports = {
       {
         test: /\.js$/,
         include: [path.resolve(__dirname, "./extension")],
-        use: "babel-loader",
+        use: [cacheLoader, "babel-loader"],
       },
       {
         test: /\.less/,
         use: [
+          cacheLoader,
           MiniCssExtractPlugin.loader,
           "css-loader",
           {
@@ -85,12 +91,12 @@ module.exports = {
       },
       {
         test: /\.css/,
-        use: ["style-loader", "css-loader"],
+        use: [cacheLoader, "style-loader", "css-loader"],
       },
       {
         test: /\.(png|ttf|eot|svg|woff(2)?)(\?[a-z0-9=&.]+)?$/,
-        loader: "file-loader",
+        loader: [cacheLoader, "file-loader"],
       },
     ],
   },
-};
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -2727,6 +2727,11 @@ buffer-from@^1.0.0:
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.1.tgz#32713bc028f75c02fdb710d7c7bcec1f2c6070ef"
   integrity sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==
 
+buffer-json@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/buffer-json/-/buffer-json-2.0.0.tgz#f73e13b1e42f196fe2fd67d001c7d7107edd7c23"
+  integrity sha512-+jjPFVqyfF1esi9fvfUs3NqM0pH1ziZ36VP4hmA/y/Ssfo/5w5xHKfTw9BwQjoJ1w/oVtpLomqwUHKdefGyuHw==
+
 buffer-xor@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/buffer-xor/-/buffer-xor-1.0.3.tgz#26e61ed1422fb70dd42e6e36729ed51d855fe8d9"
@@ -2804,6 +2809,18 @@ cache-base@^1.0.1:
     to-object-path "^0.3.0"
     union-value "^1.0.0"
     unset-value "^1.0.0"
+
+cache-loader@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/cache-loader/-/cache-loader-4.1.0.tgz#9948cae353aec0a1fcb1eafda2300816ec85387e"
+  integrity sha512-ftOayxve0PwKzBF/GLsZNC9fJBXl8lkZE3TOsjkboHfVHVkL39iUEs1FO07A33mizmci5Dudt38UZrrYXDtbhw==
+  dependencies:
+    buffer-json "^2.0.0"
+    find-cache-dir "^3.0.0"
+    loader-utils "^1.2.3"
+    mkdirp "^0.5.1"
+    neo-async "^2.6.1"
+    schema-utils "^2.0.0"
 
 cacheable-request@^6.0.0:
   version "6.1.0"
@@ -5018,6 +5035,15 @@ find-cache-dir@^2.1.0:
     commondir "^1.0.1"
     make-dir "^2.0.0"
     pkg-dir "^3.0.0"
+
+find-cache-dir@^3.0.0:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/find-cache-dir/-/find-cache-dir-3.3.1.tgz#89b33fad4a4670daa94f855f7fbe31d6d84fe880"
+  integrity sha512-t2GDMt3oGC/v+BMwzmllWDuJF/xcDtE5j/fCGbqDD7OLuJkj0cfh1YSA5VKPvwMeLFLNDBkwOKZ2X85jGLVftQ==
+  dependencies:
+    commondir "^1.0.1"
+    make-dir "^3.0.2"
+    pkg-dir "^4.1.0"
 
 find-up@^2.1.0:
   version "2.1.0"
@@ -7381,6 +7407,13 @@ make-dir@^3.0.0:
   dependencies:
     semver "^6.0.0"
 
+make-dir@^3.0.2:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-3.1.0.tgz#415e967046b3a7f1d185277d84aa58203726a13f"
+  integrity sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==
+  dependencies:
+    semver "^6.0.0"
+
 makeerror@1.0.x:
   version "1.0.11"
   resolved "https://registry.yarnpkg.com/makeerror/-/makeerror-1.0.11.tgz#e01a5c9109f2af79660e4e8b9587790184f5a96c"
@@ -8561,7 +8594,7 @@ pkg-dir@^3.0.0:
   dependencies:
     find-up "^3.0.0"
 
-pkg-dir@^4.2.0:
+pkg-dir@^4.1.0, pkg-dir@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/pkg-dir/-/pkg-dir-4.2.0.tgz#f099133df7ede422e81d1d8448270eeb3e4261f3"
   integrity sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==
@@ -9851,6 +9884,14 @@ schema-utils@^1.0.0:
     ajv "^6.1.0"
     ajv-errors "^1.0.0"
     ajv-keywords "^3.1.0"
+
+schema-utils@^2.0.0:
+  version "2.6.6"
+  resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-2.6.6.tgz#299fe6bd4a3365dc23d99fd446caff8f1d6c330c"
+  integrity sha512-wHutF/WPSbIi9x6ctjGGk2Hvl0VOz5l3EKEuKbjPlB30mKZUzb9A5k9yEXRX3pwyqVLPvpfZZEllaFq/M718hA==
+  dependencies:
+    ajv "^6.12.0"
+    ajv-keywords "^3.4.1"
 
 schema-utils@^2.6.5:
   version "2.6.5"


### PR DESCRIPTION
This makes dev rebuilds 5x faster on my system, without affecting prod builds.

To test:

0. pull this branch
1. `yarn install` to pick up new deps
2. `yarn build:webpack-dev` to prime the cache (this would be done automatically with yarn watch, but lets make it explicit)
3. `yarn watch` and notice how much faster things are