### PR TITLE
Tweak webpack.config.js

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -15,9 +15,9 @@ const cacheLoader = {
   options: { cacheDirectory: ".webpack-cache" },
 };
 
-module.exports = (env, argv) => ({
+module.exports = (env, argv = {}) => ({
   mode: argv.mode || "development",
-  devtool: argv.mode == "production" ? "source-map" : "eval-source-map",
+  devtool: argv.mode === "production" ? "source-map" : "eval-source-map",
   entry: {
     content: "./extension/content/index.js",
     "content-scripts": "./extension/content/scripts/inject.js",


### PR DESCRIPTION
couple little tweaks. the default for `argv` is to fix an issue my IDE was reporting:

> Can't analyse webpack.config.js: coding assistance will ignore module resolution rules in this file. Possible reasons: this file is not a valid webpack configuration file or its format is not currently supported by the IDE. Error details:  Cannot read property 'mode' of undefined

r?