### PR TITLE
Add taskcluster checks to bors

### DIFF
--- a/bors.toml
+++ b/bors.toml
@@ -1,7 +1,10 @@
 status = [
   "ci/circleci: lint",
   "ci/circleci: test",
-  "ci/circleci: build-extension"
+  "ci/circleci: build-extension",
+  "t-lint-src",
+  "t-test-src",
+  "build-src"
 ]
 # Avoid including verbose details from PR bodies
 cut_body_after = "\n---\n"


### PR DESCRIPTION
We just had Circle pass and Taskcluster fail, so master is broken now. We probably won't be able to merge this until we fix those errors.