### PR TITLE
remove default version value from api.js

### DIFF
--- a/extension/content/utils/api.js
+++ b/extension/content/utils/api.js
@@ -8,6 +8,13 @@ export default class API {
     throw new Error("getBaseURL() needs to be implemented");
   }
 
+  /**
+   * @param {Object} args
+   * @param {string} args.url
+   * @param {number} [args.version]
+   * @param {Object} [args.extraHeaders]
+   * @param {string|FormData} [args.body]
+   */
   async request({ url, version, extraHeaders = {}, ...options }) {
     const headers = new Headers();
     headers.append("Accept", "application/json");

--- a/extension/content/utils/api.js
+++ b/extension/content/utils/api.js
@@ -8,7 +8,7 @@ export default class API {
     throw new Error("getBaseURL() needs to be implemented");
   }
 
-  async request({ url, extraHeaders = {}, version = 3, ...options }) {
+  async request({ url, version, extraHeaders = {}, ...options }) {
     const headers = new Headers();
     headers.append("Accept", "application/json");
     if (!(options.body && options.body instanceof FormData)) {


### PR DESCRIPTION
fixes #130 
So... I took a stab at this....

removed the version value default since the experimenter api uses version value of 1?