### PR TITLE
Revert "Merge #127"

### DIFF
--- a/bors.toml
+++ b/bors.toml
@@ -1,10 +1,7 @@
 status = [
   "ci/circleci: lint",
   "ci/circleci: test",
-  "ci/circleci: build-extension",
-  "t-lint-src",
-  "t-test-src",
-  "build-src"
+  "ci/circleci: build-extension"
 ]
 # Avoid including verbose details from PR bodies
 cut_body_after = "\n---\n"


### PR DESCRIPTION
This reverts commit 270e5175f5b573a24510f5c2f1ab4eacca32e0e1, reversing
changes made to 1bdba11db8be916e0249ba39c918be2dbd631736.

This is to unblock merges while @escapewindow figures out why TC wasn't kicking off for bors merges.

r?