### PR TITLE
Use version from package.json in non-development

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -142,12 +142,14 @@ module.exports = async (env, argv = {}) => {
 
 async function getBuildInfo(isDevelopment) {
   const rv = {
-    version: (await execOutput("git describe --dirty=-uc")).trim(),
     commitHash: (await execOutput("git rev-parse HEAD")).trim(),
   };
 
   if (isDevelopment) {
     rv.isDevelopment = true;
+    rv.version = (await execOutput("git describe --dirty=-uc")).trim();
+  } else {
+    rv.version = packageData.version;
   }
 
   if (rv.version.endsWith("-uc")) {


### PR DESCRIPTION
Taskcluster doesn't build from tags, so if we pull versions from tags we don't get the right thing. This should fix that for now.