### PR TITLE
Build info updated on watch and style tweaks to version popover

### DIFF
--- a/extension/.eslintrc.js
+++ b/extension/.eslintrc.js
@@ -5,5 +5,6 @@ module.exports = {
   },
   globals: {
     __BUILD__: false,
+    DEVELOPMENT: false,
   },
 };

--- a/extension/background.js
+++ b/extension/background.js
@@ -4,7 +4,7 @@ browser.browserAction.onClicked.addListener(async () => {
   });
 });
 
-if (__BUILD__.isDevelopment) {
+if (DEVELOPMENT) {
   browser.tabs.create({
     url: "restore.html",
   });

--- a/extension/content/components/common/AppSidebar.tsx
+++ b/extension/content/components/common/AppSidebar.tsx
@@ -1,29 +1,12 @@
 import React from "react";
 import { NavLink } from "react-router-dom";
-import { Icon, Nav, Sidenav, Popover, Whisper } from "rsuite";
+import { Icon, Nav, Sidenav, Popover, Whisper, TagGroup, Tag } from "rsuite";
 
 import { useEnvironmentState } from "devtools/contexts/environment";
 import { splitCamelCase } from "devtools/utils/helpers";
 
 export const AppSidebar: React.FC = () => {
   const { selectedKey } = useEnvironmentState();
-
-  const versionPopover = (
-    <Popover>
-      <dl>
-        {Object.entries(__BUILD__).map(([key, value]) => {
-          return (
-            <React.Fragment key={key}>
-              <dt>{splitCamelCase(key, { case: "title-case" })}</dt>
-              <dd>
-                {typeof value === "string" ? value : JSON.stringify(value)}
-              </dd>
-            </React.Fragment>
-          );
-        })}
-      </dl>
-    </Popover>
-  );
 
   return (
     <div className="app-sidebar">
@@ -60,13 +43,52 @@ export const AppSidebar: React.FC = () => {
             </Nav.Item>
           </Nav>
 
-          <div className="text-subtle cursor-pointer p-2 flex-grow-0">
-            <Whisper placement="topStart" speaker={versionPopover}>
-              <span>{__BUILD__.version}</span>
+          <div className="p-2 flex-grow-0">
+            <Whisper placement="topStart" speaker={<VersionPopover />}>
+              <span className="text-subtle cursor-default">
+                v{__BUILD__.version}
+              </span>
             </Whisper>
           </div>
         </Sidenav.Body>
       </Sidenav>
     </div>
+  );
+};
+
+const VersionPopover: React.FC = (props) => {
+  const buildKeys = ["commitHash", "version"];
+
+  let tagGroup = null;
+  if (DEVELOPMENT) {
+    tagGroup = (
+      <TagGroup className="mt-2 mb-1">
+        <Tag color="blue">Development</Tag>
+        {__BUILD__.hasUncommittedChanges ? (
+          <Tag color="orange">Uncommitted Changes</Tag>
+        ) : null}
+      </TagGroup>
+    );
+  }
+
+  return (
+    <Popover {...props}>
+      <dl>
+        {buildKeys.map((key) => {
+          const value = __BUILD__[key];
+          return (
+            <React.Fragment key={key}>
+              <dt>{splitCamelCase(key, { case: "title-case" })}</dt>
+              <dd>
+                <code className="text-subtle">
+                  {typeof value === "string" ? value : JSON.stringify(value)}
+                </code>
+              </dd>
+            </React.Fragment>
+          );
+        })}
+      </dl>
+      {tagGroup}
+    </Popover>
   );
 };

--- a/extension/content/hooks/urls.ts
+++ b/extension/content/hooks/urls.ts
@@ -10,7 +10,7 @@ export function useExtensionUrl(): URL {
 }
 
 export function useHistoryRecorder(): void {
-  if (__BUILD__.isDevelopment) {
+  if (DEVELOPMENT) {
     const extensionUrl = useExtensionUrl();
     React.useEffect(() => {
       window.localStorage.setItem(

--- a/types/global/index.d.ts
+++ b/types/global/index.d.ts
@@ -1,8 +1,10 @@
 declare const __BUILD__: {
-  isDevelopment: boolean;
   version: string;
   commitHash: string;
+  hasUncommittedChanges: boolean;
 };
+
+declare const DEVELOPMENT: boolean;
 
 declare namespace browser.experiments.normandy {
   type V1Recipe = {};


### PR DESCRIPTION
A few changes here:
- `__BUILD__` now updates on every watch build.
- `DEVELOPMENT` moved back out of `__BUILD__` since making `__BUILD__` watchable means it's uncacheable and files that use it become uncacheable.
- Version for build adheres to semver standard format better:
  `<major>.<minor>.<patch>-<prerelease>+<buildmetadata>`
- Style tweaks to the popover.

<img src="https://user-images.githubusercontent.com/987136/80859140-4c9c9000-8c2c-11ea-9c94-3ede33b86674.png" width="350" />

<img src="https://user-images.githubusercontent.com/987136/80859146-5a521580-8c2c-11ea-88a1-ae3a49e58070.png" width="350" />
