### PR TITLE
Refresh auth tokens before they expire

### DIFF
--- a/extension/content/components/common/AppHeader.js
+++ b/extension/content/components/common/AppHeader.js
@@ -10,6 +10,7 @@ import {
   IconButton,
   Input,
   InputGroup,
+  Loader,
   Modal,
   Popover,
   SelectPicker,
@@ -175,7 +176,7 @@ function Authenticator() {
   const auth = useSelectedEnvironmentAuth();
   const dispatch = useEnvironmentDispatch();
   const environment = useSelectedEnvironment();
-  const { selectedKey } = useEnvironmentState();
+  const { isLoggingIn, selectedKey } = useEnvironmentState();
 
   const handleLoginClick = () => {
     login(dispatch, selectedKey, environment);
@@ -184,6 +185,14 @@ function Authenticator() {
   const handleLogoutClick = () => {
     logout(dispatch, selectedKey);
   };
+
+  if (isLoggingIn) {
+    return (
+      <div className="d-flex align-items-center justify-content-center h-100 w-110px">
+        <Loader content="Logging In&hellip;"></Loader>
+      </div>
+    );
+  }
 
   if (auth.result) {
     const { idTokenPayload: profile } = auth.result;
@@ -204,7 +213,7 @@ function Authenticator() {
         }
         trigger="click"
       >
-        <div className="d-flex">
+        <div className="d-flex cursor-pointer">
           <Avatar
             circle
             alt={profile.email.substring(0, 1)}

--- a/extension/content/contexts/environment.js
+++ b/extension/content/contexts/environment.js
@@ -356,13 +356,18 @@ async function launchWebAuthFlow(
 
   const webAuth = getWebAuthForEnvironment(environment);
 
+  const buildUrlOptions = {
+    state,
+    nonce,
+  };
+
+  if ("interactive" in details && !details.interactive) {
+    buildUrlOptions.prompt = "none";
+  }
+
   const redirectUri = await browser.identity.launchWebAuthFlow({
     interactive: true,
-    url: webAuth.client.buildAuthorizeUrl({
-      state,
-      nonce,
-      ...(details.interactive === false ? { prompt: "none" } : {}),
-    }),
+    url: webAuth.client.buildAuthorizeUrl(buildUrlOptions),
     ...details,
   });
 

--- a/extension/content/less/main.less
+++ b/extension/content/less/main.less
@@ -184,8 +184,6 @@ code.hljs {
 }
 
 .authenticator {
-  cursor: pointer;
-
   .d-flex {
     align-items: center;
   }

--- a/extension/content/less/utilities/sizing.less
+++ b/extension/content/less/utilities/sizing.less
@@ -13,11 +13,7 @@ each(@dimensions, .(@d) {
     .@{abbrev}-@{sk} { @{prop}: @sv !important };
   });
 
-  each(range(10, 90, 10), {
-    .@{abbrev}-@{value}px { @{prop}: @value * 1px !important };
-  });
-
-  each(range(100, 2000, 100), {
+  each(range(10, 2000, 10), {
     .@{abbrev}-@{value}px { @{prop}: @value * 1px !important };
   });
 })

--- a/extension/content/utils/timeConstants.js
+++ b/extension/content/utils/timeConstants.js
@@ -1,0 +1,5 @@
+export const MILLISECOND = 1;
+export const SECOND = 1000 * MILLISECOND;
+export const MINUTE = 60 * SECOND;
+export const HOUR = 60 * MINUTE;
+export const DAY = 24 * HOUR;


### PR DESCRIPTION
A few features:
- Checks if any tokens have expired every 10 minutes. If they are going to expire within 10 minutes of the check they are refreshed. If the refresh fails (typically because user interaction is required) the user is logged out.
- Login is now attempted non-interactively first so there's no pop up with you are already signed in with SSO. If action is required a pop up will be displayed.

Fixes #68 

r?