### PR TITLE
changed isHighVolume -> isHighPopulation

### DIFF
--- a/extension/content/components/recipes/details/arguments/MultiPreferenceExperiment.js
+++ b/extension/content/components/recipes/details/arguments/MultiPreferenceExperiment.js
@@ -13,10 +13,13 @@ export default function MultiPreferenceExperiment({ data }) {
     <GenericArguments
       data={data.arguments}
       formatters={{
-        "row-1": multiColumnFormatter(["isEnrollmentPaused", "isHighVolume"], {
-          isEnrollmentPaused: booleanFormatter,
-          isHighVolume: booleanFormatter,
-        }),
+        "row-1": multiColumnFormatter(
+          ["isEnrollmentPaused", "isHighPopulation"],
+          {
+            isEnrollmentPaused: booleanFormatter,
+            isHighPopulation: booleanFormatter,
+          },
+        ),
         branches(key, value) {
           const panels = value.map((branch, index) => {
             const preferences = Object.entries(branch.preferences);
@@ -116,7 +119,7 @@ export default function MultiPreferenceExperiment({ data }) {
           );
         },
       }}
-      omit={["isEnrollmentPaused", "isHighVolume"]}
+      omit={["isEnrollmentPaused", "isHighPopulation"]}
       ordering={[
         "userFacingName",
         "userFacingDescription",

--- a/extension/content/components/recipes/details/arguments/PreferenceExperiment.js
+++ b/extension/content/components/recipes/details/arguments/PreferenceExperiment.js
@@ -27,10 +27,13 @@ export default function PreferenceExperiment({ data }) {
             preferenceBranchType: tagFormatter(),
           },
         ),
-        "row-3": multiColumnFormatter(["isEnrollmentPaused", "isHighVolume"], {
-          isEnrollmentPaused: booleanFormatter,
-          isHighVolume: booleanFormatter,
-        }),
+        "row-3": multiColumnFormatter(
+          ["isEnrollmentPaused", "isHighPopulation"],
+          {
+            isEnrollmentPaused: booleanFormatter,
+            isHighPopulation: booleanFormatter,
+          },
+        ),
         branches: tableFormatter(["slug", "ratio", "value"], {
           slug(index, value) {
             return <code>{value}</code>;
@@ -57,7 +60,7 @@ export default function PreferenceExperiment({ data }) {
         "preferenceType",
         "preferenceBranchType",
         "isEnrollmentPaused",
-        "isHighVolume",
+        "isHighPopulation",
       ]}
       ordering={[
         "row-1",

--- a/extension/content/components/recipes/form/ActionArguments.js
+++ b/extension/content/components/recipes/form/ActionArguments.js
@@ -56,7 +56,7 @@ export const INITIAL_ACTION_ARGUMENTS = {
     branches: [],
     experimentDocumentUrl: "",
     isEnrollmentPaused: false,
-    isHighVolume: false,
+    isHighPopulation: false,
     preferenceBranchType: "default",
     preferenceName: "",
     preferenceType: "boolean",

--- a/extension/content/components/recipes/form/arguments/MultiPreference.js
+++ b/extension/content/components/recipes/form/arguments/MultiPreference.js
@@ -38,7 +38,7 @@ export default function MultiPreference() {
       <FormGroup>
         <Row>
           <Col xs={12}>
-            <ToggleField label="High Volume Recipe" name="isHighVolume">
+            <ToggleField label="High Volume Recipe" name="isHighPopulation">
               Affects the experiment type reported to telemetry, and can be used
               to filter recipe data in analysis. This should be set to true on
               recipes that affect a significant percentage of release.

--- a/extension/content/components/recipes/form/arguments/PreferenceExperiment.js
+++ b/extension/content/components/recipes/form/arguments/PreferenceExperiment.js
@@ -98,7 +98,7 @@ export default function PreferenceExperiment() {
       <FormGroup>
         <Row>
           <Col xs={12}>
-            <ToggleField label="High Volume Recipe" name="isHighVolume">
+            <ToggleField label="High Volume Recipe" name="isHighPopulation">
               Affects the experiment type reported to telemetry, and can be used
               to filter recipe data in analysis. This should be set to true on
               recipes that affect a significant percentage of release.


### PR DESCRIPTION
@mythmon pointed out that in devtools we have the field isHighVolume for pref experiments rather than the isHighPopulation, I think these changes should correct that.