### PR TITLE
Update babel requirements to only recent Firefox and Node

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -7,15 +7,6 @@
   ],
   "plugins": [
     ["@babel/plugin-proposal-decorators", { "legacy": true, "loose": true }],
-    "@babel/plugin-proposal-object-rest-spread",
-    "@babel/plugin-proposal-async-generator-functions",
-    "@babel/plugin-proposal-class-properties",
-    [
-      "@babel/plugin-transform-runtime",
-      {
-        "helpers": false,
-        "regenerator": true
-      }
-    ]
+    "@babel/plugin-proposal-class-properties"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -28,11 +28,8 @@
   },
   "devDependencies": {
     "@babel/core": "7.10.3",
-    "@babel/plugin-proposal-async-generator-functions": "7.10.1",
     "@babel/plugin-proposal-class-properties": "7.8.3",
     "@babel/plugin-proposal-decorators": "7.10.3",
-    "@babel/plugin-proposal-object-rest-spread": "7.10.1",
-    "@babel/plugin-transform-runtime": "7.10.1",
     "@babel/preset-env": "7.10.3",
     "@babel/preset-react": "7.10.1",
     "@babel/preset-typescript": "7.10.1",
@@ -111,5 +108,6 @@
   },
   "resolutions": {
     "web-ext/addons-linter": "1.24.0"
-  }
+  },
+  "browserslist": "last 2 firefox versions, node >= 12"
 }

--- a/tests/components/recipes/details/arguments/GenericArguments.test.tsx
+++ b/tests/components/recipes/details/arguments/GenericArguments.test.tsx
@@ -1,0 +1,94 @@
+import { render, cleanup } from "@testing-library/react";
+import React from "react";
+
+import GenericArguments from "devtools/components/recipes/details/arguments/GenericArguments";
+
+afterEach(async () => {
+  jest.clearAllMocks();
+  await cleanup();
+});
+
+describe("GenericArguments", () => {
+  it("should sorts items by keys, and branches are alway at the end", () => {
+    const doc = render(
+      <GenericArguments
+        data={{
+          banana: "yellow",
+          apple: "green",
+          branches: "brown",
+          cherry: "red",
+        }}
+      />,
+    );
+    const textContents = doc.getAllByText(/.+/).map((el) => el.textContent);
+    expect(textContents).toEqual([
+      "Apple",
+      "green",
+      "Banana",
+      "yellow",
+      "Cherry",
+      "red",
+      "Branches",
+      "brown",
+    ]);
+  });
+
+  it("should show keys with an empty value specially", () => {
+    const doc = render(<GenericArguments data={{ empty: "" }} />);
+    const textContents = doc.getAllByText(/.+/).map((el) => el.textContent);
+    expect(textContents).toEqual(["Empty", "(no value set)"]);
+    const emptyValue = doc.getByText("(no value set)");
+    expect(emptyValue.tagName.toLowerCase()).toEqual("code");
+  });
+
+  it("should show booleans specially", () => {
+    const doc = render(<GenericArguments data={{ yes: true, no: false }} />);
+
+    const trueEl = doc.getByText("True");
+    expect(trueEl).toHaveClass("rs-tag-text");
+    expect(trueEl.parentElement).toHaveClass("rs-tag-green");
+
+    const falseEl = doc.getByText("False");
+    expect(falseEl).toHaveClass("rs-tag-text");
+    expect(falseEl.parentElement).toHaveClass("rs-tag-red");
+  });
+
+  it("should show booleans with an 'is' prefix specially", () => {
+    const doc = render(
+      <GenericArguments data={{ isYes: true, isNo: false }} />,
+    );
+
+    const yesEl = doc.getByText("Yes");
+    expect(yesEl).toHaveClass("rs-tag-text");
+    expect(yesEl.parentElement).toHaveClass("rs-tag-green");
+
+    const noEl = doc.getByText("No");
+    expect(noEl).toHaveClass("rs-tag-text");
+    expect(noEl.parentElement).toHaveClass("rs-tag-red");
+  });
+
+  it("should recurse and show lists for arrays", () => {
+    const doc = render(
+      <GenericArguments
+        data={{
+          items: [
+            { a: 1, b: 2 },
+            { c: 3, d: 4 },
+          ],
+        }}
+      />,
+    );
+    const textContents = doc.getAllByText(/.+/).map((el) => el.textContent);
+    expect(textContents).toEqual([
+      "Items",
+      "A",
+      "1",
+      "B",
+      "2",
+      "C",
+      "3",
+      "D",
+      "4",
+    ]);
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -364,15 +364,6 @@
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.10.3.tgz#7e71d892b0d6e7d04a1af4c3c79d72c1f10f5315"
   integrity sha512-oJtNJCMFdIMwXGmx+KxuaD7i3b8uS7TTFYW/FNG2BT8m+fmGHoiPYoH0Pe3gya07WuFmM5FCDIr1x0irkD/hyA==
 
-"@babel/plugin-proposal-async-generator-functions@7.10.1":
-  version "7.10.1"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.10.1.tgz#6911af5ba2e615c4ff3c497fe2f47b35bf6d7e55"
-  integrity sha512-vzZE12ZTdB336POZjmpblWfNNRpMSua45EYnRigE2XsZxcXcIyly2ixnTJasJE4Zq3U7t2d8rRF7XRUuzHxbOw==
-  dependencies:
-    "@babel/helper-plugin-utils" "^7.10.1"
-    "@babel/helper-remap-async-to-generator" "^7.10.1"
-    "@babel/plugin-syntax-async-generators" "^7.8.0"
-
 "@babel/plugin-proposal-async-generator-functions@^7.10.3":
   version "7.10.3"
   resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.10.3.tgz#5a02453d46e5362e2073c7278beab2e53ad7d939"
@@ -438,15 +429,6 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.10.1"
     "@babel/plugin-syntax-numeric-separator" "^7.10.1"
-
-"@babel/plugin-proposal-object-rest-spread@7.10.1":
-  version "7.10.1"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.10.1.tgz#cba44908ac9f142650b4a65b8aa06bf3478d5fb6"
-  integrity sha512-Z+Qri55KiQkHh7Fc4BW6o+QBuTagbOp9txE+4U1i79u9oWlf2npkiDx+Rf3iK3lbcHBuNy9UOkwuR5wOMH3LIQ==
-  dependencies:
-    "@babel/helper-plugin-utils" "^7.10.1"
-    "@babel/plugin-syntax-object-rest-spread" "^7.8.0"
-    "@babel/plugin-transform-parameters" "^7.10.1"
 
 "@babel/plugin-proposal-object-rest-spread@^7.10.3":
   version "7.10.3"
@@ -842,16 +824,6 @@
   integrity sha512-qN1OMoE2nuqSPmpTqEM7OvJ1FkMEV+BjVeZZm9V9mq/x1JLKQ4pcv8riZJMNN3u2AUGl0ouOMjRr2siecvHqUQ==
   dependencies:
     "@babel/helper-plugin-utils" "^7.10.1"
-
-"@babel/plugin-transform-runtime@7.10.1":
-  version "7.10.1"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.10.1.tgz#fd1887f749637fb2ed86dc278e79eb41df37f4b1"
-  integrity sha512-4w2tcglDVEwXJ5qxsY++DgWQdNJcCCsPxfT34wCUwIf2E7dI7pMpH8JczkMBbgBTNzBX62SZlNJ9H+De6Zebaw==
-  dependencies:
-    "@babel/helper-module-imports" "^7.10.1"
-    "@babel/helper-plugin-utils" "^7.10.1"
-    resolve "^1.8.1"
-    semver "^5.5.1"
 
 "@babel/plugin-transform-shorthand-properties@^7.10.1":
   version "7.10.1"
@@ -3083,14 +3055,14 @@ camelcase@^6.0.0:
   integrity sha512-8KMDF1Vz2gzOq54ONPJS65IvTUaB1cHJ2DMM7MbPmLZljDH1qpzzLsWdiN9pHh6qvkRVDTi/07+eNGch/oLU4w==
 
 caniuse-lite@^1.0.30001039:
-  version "1.0.30001039"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001039.tgz#b3814a1c38ffeb23567f8323500c09526a577bbe"
-  integrity sha512-SezbWCTT34eyFoWHgx8UWso7YtvtM7oosmFoXbCkdC6qJzRfBTeTgE9REtKtiuKXuMwWTZEvdnFNGAyVMorv8Q==
+  version "1.0.30001094"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001094.tgz"
+  integrity sha512-ufHZNtMaDEuRBpTbqD93tIQnngmJ+oBknjvr0IbFympSdtFpAUFmNv4mVKbb53qltxFx0nK3iy32S9AqkLzUNA==
 
 caniuse-lite@^1.0.30001043:
-  version "1.0.30001079"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001079.tgz#ed3e5225cd9a6850984fdd88bf24ce45d69b9c22"
-  integrity sha512-2KaYheg0iOY+CMmDuAB3DHehrXhhb4OZU4KBVGDr/YKyYAcpudaiUQ9PJ9rxrPlKEoJ3ATasQ5AN48MqpwS43Q==
+  version "1.0.30001094"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001094.tgz"
+  integrity sha512-ufHZNtMaDEuRBpTbqD93tIQnngmJ+oBknjvr0IbFympSdtFpAUFmNv4mVKbb53qltxFx0nK3iy32S9AqkLzUNA==
 
 capture-exit@^2.0.0:
   version "2.0.0"
@@ -10151,7 +10123,7 @@ resolve@1.1.7:
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
   integrity sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=
 
-resolve@^1.1.6, resolve@^1.10.0, resolve@^1.12.0, resolve@^1.13.1, resolve@^1.15.1, resolve@^1.17.0, resolve@^1.3.2, resolve@^1.8.1:
+resolve@^1.1.6, resolve@^1.10.0, resolve@^1.12.0, resolve@^1.13.1, resolve@^1.15.1, resolve@^1.17.0, resolve@^1.3.2:
   version "1.17.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.17.0.tgz#b25941b54968231cc2d1bb76a79cb7f2c0bf8444"
   integrity sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==


### PR DESCRIPTION
This means the code is built with fewer transforms, and so it is closer to the original code, making it easier to debug. It's also smaller and builds faster.