### PR TITLE
Fix bug in direct bucket sample method

### DIFF
--- a/extension/content/utils/recipes.ts
+++ b/extension/content/utils/recipes.ts
@@ -48,11 +48,12 @@ export async function bruteForceBucketSample(
   const maxTrials = (filter.total / filter.count) * 10;
   for (let i = 0; i < maxTrials; i++) {
     const fakeClientId = `test-userId-${i}`;
+    const fakeClientIdStr = `"${fakeClientId}"`;
     const newInput = filter.input.map((inp) =>
-      inp === "normandy.userId" ? fakeClientId : inp,
+      inp === "normandy.userId" ? fakeClientIdStr : inp,
     );
     assert(
-      newInput.includes(fakeClientId),
+      newInput.includes(fakeClientIdStr),
       "Fake client ID not inserted. This is a bug.",
     );
 

--- a/extension/experiments/normandy/api.js
+++ b/extension/experiments/normandy/api.js
@@ -271,7 +271,12 @@ var normandy = class extends ExtensionAPI {
           },
 
           async bucketSample(input, start, count, total) {
-            return Sampling.bucketSample(input, start, count, total);
+            return Sampling.bucketSample(
+              input.map(JSON.parse),
+              start,
+              count,
+              total,
+            );
           },
         },
       },


### PR DESCRIPTION
The inputs of sampling arguments are JEXL expressions, so to provide a fake ID
we should pass it as a string. Additionally, it should be processed as a JEXL
expressoin by the `bucketSample` bypass method. Parsing it as JSON is close
enough for our purposes.

Fixes #328.