### PR TITLE
Turn off dependabot auto-rebasing

### DIFF
--- a/dependabot.yml
+++ b/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "live"
+    # Disable rebasing, since it interferes with Bors
+    rebase-strategy: "disabled"
+


### PR DESCRIPTION
Dependabot is rebasing PRs that don't have any conflicts, which makes bors only able to merge one at t ime. This makes managing Dependabot PRs in this repo a lot harder. Turning it off will mean we'll have to manually trigger Dependabot rebasing when it is needed, but that's pretty uncommon for us.