### PR TITLE
Fix overlapping form inputs

### DIFF
--- a/extension/content/less/main.less
+++ b/extension/content/less/main.less
@@ -215,3 +215,9 @@ code.hljs {
     }
   }
 }
+
+/* rsuite makes input groups 300px wide always for some reason, which is not
+ * helpful for us. */
+.rs-form-vertical .rs-form-group .rs-input-group {
+  width: auto;
+}


### PR DESCRIPTION
We picked this up in the rsuite 4.7.5 -> 4.8.0 upgrade. I see the change happened in [this PR](https://github.com/rsuite/rsuite/pull/1158), but I can't see any reason why that value was chosen.

### Before
![2020-09-02-154705_screenshot](https://user-images.githubusercontent.com/305049/92044740-bf7d5b00-ed33-11ea-85cc-82e3fa1f32bd.png)


### After
![2020-09-02-154740_screenshot](https://user-images.githubusercontent.com/305049/92044746-c1dfb500-ed33-11ea-9413-f073c682c592.png)
