### PR TITLE
Fix #404: in-page address bar is now editable

### DIFF
--- a/extension/content/components/common/AppHeader.js
+++ b/extension/content/components/common/AppHeader.js
@@ -63,7 +63,12 @@ function AddressBar() {
   let inputRef;
   let triggerRef;
 
-  React.useEffect(() => setAddress(extensionUrl.toString()), [extensionUrl]);
+  React.useEffect(() => {
+    // Show current address if user is not interacting with the input.
+    if (document.activeElement !== inputRef) {
+      setAddress(extensionUrl.toString());
+    }
+  }, [extensionUrl]);
 
   const handleKeyPress = (ev) => {
     if (ev.key === "Enter") {


### PR DESCRIPTION
Fix #404

With this change, the in-page addressbar is not constantly overwritten. The effect/hook was marked as depending from `extensionURL`, which becomes different than edited value after first stroke. 