### PR TITLE
Change dependabot schedule to daily

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "live"
+      interval: "daily"
     # Disable rebasing, since it interferes with Bors
     rebase-strategy: "disabled"
 


### PR DESCRIPTION
Live is not a supported value in Github Dependabot. It produces this error:

> The property '#/updates/0/schedule/interval' value "live" did not match one of the following values: daily, weekly, monthly