### PR TITLE
Don't calculate coverage for Dependabot PRs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,7 +49,14 @@ jobs:
           key: v2-dependencies-{{ checksum "yarn.lock" }}
       - run:
           name: Run tests
-          command: yarn test
+          command: |
+            # Don't include coverage for Dependabot; it's noisy and rarely tells us anything useful.
+            if [[ "$CIRCLE_USERNAME" -eq "dependabot[bot]" ]]; then
+              yarn test
+            else
+              yarn test --coverage
+            fi
+      # This will only upload if a coverage file was actually generated.
       - codecov/upload:
           file: coverage/coverage-final.json
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -18,6 +18,6 @@ module.exports = {
     "^devtools/(.*)$": "<rootDir>/extension/content/$1",
     "\\.(less|css)$": "identity-obj-proxy",
   },
-  collectCoverage: true,
+  collectCoverage: false,
   collectCoverageFrom: ["<rootDir>/extension/content/**/*.{js,ts,tsx}"],
 };


### PR DESCRIPTION
Dependabot PRs often change test coverage even though there isn't any actual
difference. This makes the automated CI checks less useful since about half
of Dependabot PRs have a false-negative red X on the PR summary.
