### PR TITLE
Fix syntax error in generated files

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,6 +83,9 @@ jobs:
       - run:
           name: Build extension
           command: yarn build
+      - run:
+          name: Syntax check built output
+          command: ls dist/*.js | xargs -l node --check
       - store_artifacts:
           path: web-ext-artifacts
 

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "cache-loader": "4.1.0",
     "copy-webpack-plugin": "6.1.0",
     "css-loader": "4.3.0",
-    "dotenv-webpack": "3.0.0",
+    "dotenv-webpack": "2.0.0",
     "eslint": "6.8.0",
     "eslint-config-prettier": "6.11.0",
     "eslint-plugin-fetch-options": "0.0.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4281,19 +4281,19 @@ dot-prop@^5.2.0:
   dependencies:
     is-obj "^2.0.0"
 
-dotenv-defaults@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/dotenv-defaults/-/dotenv-defaults-2.0.1.tgz#ea6f9632b3b5cc55e48b736760def5561f1cb7c0"
-  integrity sha512-ugFCyBF7ILuwpmznduHPQZBMucHHJ8T4OBManTEVjemxCm2+nqifSuW2lD2SNKdiKSH1E324kZSdJ8M04b4I/A==
+dotenv-defaults@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/dotenv-defaults/-/dotenv-defaults-2.0.0.tgz#f48577d885c7755d2a4ce1f7f3706552c0cb367e"
+  integrity sha512-8X8gQoM+BH0L/v+GwgpeNwrthbG2uTDVr3vkbedQPLrIalZE0vxB9LbuD+7echbiP7fAY3tE+pZI11R1DtlUNg==
   dependencies:
     dotenv "^8.2.0"
 
-dotenv-webpack@3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/dotenv-webpack/-/dotenv-webpack-3.0.0.tgz#ff4af756f0f85c858d4d381a767b33e717b568ed"
-  integrity sha512-HsBTgVbh9E71IdC6QcQTnAuVt11niA5QMKblcBqhVBxP975XPGMqxf21pqgVBPyRKn2GqPh5kSHMgjxeR/HEAA==
+dotenv-webpack@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/dotenv-webpack/-/dotenv-webpack-2.0.0.tgz#064ae42dbb214778d8aff0c76dc97253594f9ec3"
+  integrity sha512-Omo5IpVl7XRgWXeZjxdfqOBEApJPxGLMOIx3F/w/W7ppUKgYMOXrk4eczlQrErPD4X0YRESlyGJek3O4uobRnw==
   dependencies:
-    dotenv-defaults "^2.0.1"
+    dotenv-defaults "^2.0.0"
 
 dotenv@^8.2.0:
   version "8.2.0"


### PR DESCRIPTION
This was caused by a recent update to dotenv-webpack, in #451. I expect they are going to revert that change. For now though, we're going to revert the bump on our end, and add a CI check that would have caught it.

Fixes #453
