### PR TITLE
Fix #404: fix press enter in address bar

### DIFF
--- a/content/components/common/AppHeader.js
+++ b/content/components/common/AppHeader.js
@@ -72,8 +72,10 @@ function AddressBar() {
 
   const handleKeyPress = (ev) => {
     if (ev.key === "Enter") {
-      const addressMatch = address.match(/ext\+normandy:\/(.+?)$/);
-      history.push(addressMatch[1]);
+      const addressMatch = address.match(/\+normandy:\/(.+?)$/);
+      if (addressMatch) {
+        history.push(addressMatch[1]);
+      }
     }
   };
 


### PR DESCRIPTION
Fix #404

- code would crash if match pattern is `null`
- pattern wouldn't match `web+normandy://`