### PR TITLE
Show correct status for recipe on details page

### DIFF
--- a/content/components/pages/RecipeDetailsPage.tsx
+++ b/content/components/pages/RecipeDetailsPage.tsx
@@ -18,11 +18,13 @@ const RecipeDetailsPage: React.FC = () => {
   const [recipeData, setRecipeData] = React.useState({
     experimenter_slug: null,
   });
+  const [recipeStatusData, setRecipeStatusData] = React.useState(null);
   const [experimenterData, setExperimenterData] = React.useState(null);
 
   React.useEffect(() => {
     normandyApi.fetchRecipe(recipeId).then((recipeData) => {
       setRecipeData(recipeData.latest_revision);
+      setRecipeStatusData(recipeData.approved_revision);
     });
   }, [recipeId, normandyApi.getBaseUrl({ method: "GET" })]);
 
@@ -56,7 +58,7 @@ const RecipeDetailsPage: React.FC = () => {
   }, [recipeData]);
 
   return (
-    <RecipeDetailsProvider data={recipeData}>
+    <RecipeDetailsProvider data={recipeData} statusData={recipeStatusData}>
       <ExperimenterDetailsProvider data={experimenterData}>
         <div className="d-flex flex-column h-100">
           <DetailsHeader />

--- a/content/components/recipes/details/ApprovalRequest.tsx
+++ b/content/components/recipes/details/ApprovalRequest.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { useParams } from "react-router-dom";
 import { Alert, Button, Divider, Input, Tag } from "rsuite";
 
 import CollapsibleSection from "devtools/components/recipes/details/CollapsibleSection";
@@ -9,7 +10,8 @@ import {
   useRecipeDetailsDispatch,
 } from "devtools/contexts/recipeDetails";
 
-export default function ApprovalRequest() {
+const ApprovalRequest: React.FC = () => {
+  const { recipeId } = useParams<{ recipeId: string }>();
   const data = useRecipeDetailsData();
   const dispatch = useRecipeDetailsDispatch();
   const normandyApi = useSelectedNormandyEnvironmentAPI();
@@ -30,7 +32,7 @@ export default function ApprovalRequest() {
     statusTag = <Tag color="red">Rejected</Tag>;
   }
 
-  const handleClickApprove = async () => {
+  const handleClickApprove = async (): Promise<void> => {
     setIsApproving(true);
     try {
       const updatedApprovalRequest = await normandyApi.approveApprovalRequest(
@@ -44,6 +46,14 @@ export default function ApprovalRequest() {
         },
         type: ACTION_UPDATE_DATA,
       });
+      normandyApi.fetchRecipe(recipeId).then((recipeData) => {
+        dispatch({
+          data: recipeData.latest_revision,
+          statusData:
+            recipeData.approved_revision || recipeData.latest_revision,
+          type: ACTION_UPDATE_DATA,
+        });
+      });
     } catch (err) {
       console.warn(err.message, err.data);
       Alert.error(`An Error Occurred: ${err.message}`, 5000);
@@ -52,7 +62,7 @@ export default function ApprovalRequest() {
     }
   };
 
-  const handleClickReject = async () => {
+  const handleClickReject = async (): Promise<void> => {
     setIsRejecting(true);
     try {
       const updatedApprovalRequest = await normandyApi.rejectApprovalRequest(
@@ -74,7 +84,7 @@ export default function ApprovalRequest() {
     }
   };
 
-  const handleClickCancel = async () => {
+  const handleClickCancel = async (): Promise<void> => {
     await normandyApi.closeApprovalRequest(approvalRequest.id);
     dispatch({
       data: {
@@ -161,4 +171,6 @@ export default function ApprovalRequest() {
       <Divider />
     </>
   );
-}
+};
+
+export default ApprovalRequest;

--- a/content/components/recipes/details/RecipeDetails.tsx
+++ b/content/components/recipes/details/RecipeDetails.tsx
@@ -6,11 +6,11 @@ import ApprovalRequest from "devtools/components/recipes/details/ApprovalRequest
 import ExperimenterDetails from "devtools/components/recipes/details/ExperimenterDetails";
 import FilteringDetails from "devtools/components/recipes/details/FilteringDetails";
 import SuitabilityTag from "devtools/components/recipes/details/SuitabilityTag";
-import { useRecipeDetailsData } from "devtools/contexts/recipeDetails";
+import { useRecipeDetailsState } from "devtools/contexts/recipeDetails";
 
 // default export
 const RecipeDetails: React.FunctionComponent = () => {
-  const data = useRecipeDetailsData();
+  const { data, statusData } = useRecipeDetailsState();
   if (!data.recipe) {
     return (
       <div className="text-center">
@@ -32,8 +32,8 @@ const RecipeDetails: React.FunctionComponent = () => {
           {__ENV__ === "extension" && <SuitabilityTag />}
         </div>
         <div>
-          <Tag color={data.enabled ? "green" : "red"}>
-            {data.enabled ? "Enabled" : "Disabled"}
+          <Tag color={statusData.enabled ? "green" : "red"}>
+            {statusData.enabled ? "Enabled" : "Disabled"}
           </Tag>
         </div>
       </div>

--- a/content/components/recipes/details/SuitabilityTag.tsx
+++ b/content/components/recipes/details/SuitabilityTag.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Icon, Popover, Tag, Whisper } from "rsuite";
 
-import { useRecipeDetailsData } from "devtools/contexts/recipeDetails";
+import { useRecipeDetailsState } from "devtools/contexts/recipeDetails";
 import { Revision } from "devtools/types/recipes";
 import { convertToV1Recipe } from "devtools/utils/recipes";
 
@@ -97,7 +97,8 @@ const SuitabilityTag: React.FC<SuitabilityTagProps> = ({
   const [loading, setLoading] = React.useState(true);
 
   if (!revision) {
-    revision = useRecipeDetailsData();
+    const recipeDetailsState = useRecipeDetailsState();
+    revision = recipeDetailsState.statusData;
   }
 
   React.useEffect(() => {

--- a/content/contexts/recipeDetails.js
+++ b/content/contexts/recipeDetails.js
@@ -9,6 +9,7 @@ export const INITIAL_RECIPE_DATA = {
 
 const initialState = {
   data: INITIAL_RECIPE_DATA,
+  statusData: INITIAL_RECIPE_DATA,
   importInstructions: "",
   clientErrors: {},
 };
@@ -26,7 +27,8 @@ function reducer(state, action) {
     case ACTION_UPDATE_DATA:
       return {
         ...state,
-        data: action.data,
+        data: action.data || state.data,
+        statusData: action.statusData || state.statusData,
       };
 
     case ACTION_UPDATE_IMPORT_INSTRUCTIONS:
@@ -56,7 +58,12 @@ function reducer(state, action) {
   }
 }
 
-export function RecipeDetailsProvider({ children, data, importInstructions }) {
+export function RecipeDetailsProvider({
+  children,
+  data,
+  importInstructions,
+  statusData,
+}) {
   /** @type {[React.ReducerState<any>, React.Dispatch<React.ReducerAction<any>>]} */
   const [state, dispatch] = React.useReducer(reducer, initialState);
 
@@ -64,8 +71,9 @@ export function RecipeDetailsProvider({ children, data, importInstructions }) {
     dispatch({
       type: ACTION_UPDATE_DATA,
       data,
+      statusData: statusData || data,
     });
-  }, [data]);
+  }, [data, statusData]);
 
   React.useEffect(() => {
     dispatch({
@@ -81,6 +89,7 @@ export function RecipeDetailsProvider({ children, data, importInstructions }) {
 RecipeDetailsProvider.propTypes = {
   children: PropTypes.any,
   data: PropTypes.object.isRequired,
+  statusData: PropTypes.object,
   importInstructions: PropTypes.string,
 };
 

--- a/content/tests/components/recipes/details/RecipeDetails.test.js
+++ b/content/tests/components/recipes/details/RecipeDetails.test.js
@@ -1,4 +1,4 @@
-import { cleanup, fireEvent, render, waitFor } from "@testing-library/react";
+import { cleanup, fireEvent, waitFor } from "@testing-library/react";
 import React from "react";
 
 import "@testing-library/jest-dom/extend-expect";
@@ -392,7 +392,7 @@ describe("The `RecipeDetails` component", () => {
     global.__ENV__ = "extension";
     const recipe = recipeFactory.build();
 
-    const doc = await render(
+    const doc = renderWithContext(
       <RecipeDetailsProvider data={recipe.latest_revision}>
         <RecipeDetails />
       </RecipeDetailsProvider>,


### PR DESCRIPTION
Fixes the issue with the details page showing the wrong status when a draft revision exists. 

Also fixes a problem where the enable button is shown for enabled recipes after a new approval request is approved.

r?