### PR TITLE
Don't show testing clientIds in web mode, since they use webextension APIs

### DIFF
--- a/content/components/recipes/details/arguments/MultiPreferenceExperiment.js
+++ b/content/components/recipes/details/arguments/MultiPreferenceExperiment.js
@@ -13,7 +13,11 @@ import { useExperimenterDetailsData } from "devtools/contexts/experimenterDetail
 import { useBranchTestingIds } from "devtools/hooks/testingIds";
 
 export default function MultiPreferenceExperiment({ data }) {
-  const branchTestingIds = useBranchTestingIds(data);
+  let branchTestingIds;
+  if (__ENV__ === "extension") {
+    branchTestingIds = useBranchTestingIds(data);
+  }
+
   const experimenterData = useExperimenterDetailsData();
 
   return (
@@ -100,29 +104,31 @@ export default function MultiPreferenceExperiment({ data }) {
                       <code>{branch.ratio}</code>
                     </div>
                   </div>
-                  <div className="flex-basis-0 flex-grow-1">
-                    <div className="d-flex align-items-center">
-                      <div className="pr-2 font-weight-bold">
-                        Testing clientId
-                        <HelpIcon>
-                          Setting the preference{" "}
-                          <code>app.normandy.clientId</code> to this value will
-                          satisfy the sampling filter and choose this branch
-                          when enrolling. It will not automatically satisfy
-                          other filters.
-                        </HelpIcon>
+                  {__ENV__ === "extension" && (
+                    <div className="flex-basis-0 flex-grow-1">
+                      <div className="d-flex align-items-center">
+                        <div className="pr-2 font-weight-bold">
+                          Testing clientId
+                          <HelpIcon>
+                            Setting the preference{" "}
+                            <code>app.normandy.clientId</code> to this value
+                            will satisfy the sampling filter and choose this
+                            branch when enrolling. It will not automatically
+                            satisfy other filters.
+                          </HelpIcon>
+                        </div>
+                      </div>
+                      <div className="my-1 text-subtle">
+                        <AsyncHookView hook={branchTestingIds}>
+                          {(value) => (
+                            <code>
+                              app.normandy.clientId = {value[branch.slug]}
+                            </code>
+                          )}
+                        </AsyncHookView>
                       </div>
                     </div>
-                    <div className="my-1 text-subtle">
-                      <AsyncHookView hook={branchTestingIds}>
-                        {(value) => (
-                          <code>
-                            app.normandy.clientId = {value[branch.slug]}
-                          </code>
-                        )}
-                      </AsyncHookView>
-                    </div>
-                  </div>
+                  )}
                 </div>
 
                 <div className="mt-4">

--- a/content/components/recipes/details/filters/BucketSample.tsx
+++ b/content/components/recipes/details/filters/BucketSample.tsx
@@ -48,7 +48,12 @@ const BucketSample: React.FunctionComponent<{
               ))}
             </div>
           </div>
-          <TestingClientId className="flex-grow-1 flex-basis-0" filter={data} />
+          {__ENV__ === "extension" && (
+            <TestingClientId
+              className="flex-grow-1 flex-basis-0"
+              filter={data}
+            />
+          )}
         </div>
       </Panel>
     </div>

--- a/content/components/recipes/details/filters/NamespaceSample.tsx
+++ b/content/components/recipes/details/filters/NamespaceSample.tsx
@@ -47,7 +47,12 @@ const NamespaceSample: React.FunctionComponent<{
               </Tag>
             </div>
           </div>
-          <TestingClientId className="flex-grow-1 flex-basis-0" filter={data} />
+          {__ENV__ === "extension" && (
+            <TestingClientId
+              className="flex-grow-1 flex-basis-0"
+              filter={data}
+            />
+          )}
         </div>
       </Panel>
     </div>


### PR DESCRIPTION
I noticed that this component was (not surprisingly) showing errors in Mat's #543.