### PR TITLE
Code split less aggressively, to fix Codemirror

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -233,7 +233,6 @@ function makeWebConfig(development) {
 
     optimization: {
       minimize: !development,
-      splitChunks: { chunks: "all" },
     },
 
     plugins: [


### PR DESCRIPTION
Before, we split any chunk that could be split. With this PR we revert to Webpack's default of only splitting async chunks, which is safer. This in theory produces more overall code, since things can be duplicated between chunks. That's preferable to a broken site though.

![image](https://user-images.githubusercontent.com/305049/96915575-3f35c500-145b-11eb-9d85-753eafcd3579.png)