### PR TITLE
Make all codecov checks "informational" instead of failing CI

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -5,11 +5,8 @@ coverage:
       target: auto
       threshold: 0%
       base: auto
-    project:
-      # don't fail main-branch CI builds for coverage
-      main_branch:
-        branches: [main]
-        informational: true
+      # don't fail CI builds for coverage
+      informational: true
 
 comment:
   layout: "diff,flags,tree"


### PR DESCRIPTION
The codecov coverage reports are very useful, but flagging PRs as failing CI is noise that slows things down, at least for me. I think that the comments in the PRs are enough to provide the test coverage nudge we wanted.
