### PR TITLE
Enable eslint-plugin-react-hooks

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -57,6 +57,7 @@ module.exports = {
     "plugin:prettier/recommended",
     "plugin:mozilla/recommended",
     "plugin:react/recommended",
+    "plugin:react-hooks/recommended",
   ],
   plugins: ["mozilla", "import"],
   settings: {
@@ -98,7 +99,10 @@ module.exports = {
         "@typescript-eslint/no-use-before-define": ["off"],
         "react/prop-types": ["off"],
         "@typescript-eslint/camelcase": ["off"],
-        "@typescript-eslint/explicit-function-return-type": ["warn", {allowExpressions: true}],
+        "@typescript-eslint/explicit-function-return-type": [
+          "warn",
+          { allowExpressions: true },
+        ],
       },
     },
   ],

--- a/content/components/common/AppHeader.js
+++ b/content/components/common/AppHeader.js
@@ -70,7 +70,7 @@ function AddressBar() {
     if (document.activeElement !== inputRef) {
       setAddress(extensionUrl.toString());
     }
-  }, [extensionUrl]);
+  }, [extensionUrl, inputRef]);
 
   const handleKeyPress = (ev) => {
     if (ev.key === "Enter") {

--- a/content/components/pages/RecipeDetailsPage.tsx
+++ b/content/components/pages/RecipeDetailsPage.tsx
@@ -26,7 +26,7 @@ const RecipeDetailsPage: React.FC = () => {
       setRecipeData(recipeData.latest_revision);
       setRecipeStatusData(recipeData.approved_revision);
     });
-  }, [recipeId, normandyApi.getBaseUrl({ method: "GET" })]);
+  }, [recipeId, normandyApi]);
 
   React.useEffect(() => {
     const { experimenter_slug } = recipeData;
@@ -57,6 +57,8 @@ const RecipeDetailsPage: React.FC = () => {
         }, {}),
       });
     });
+    // XXX Adding experimenterApi here causes the tests to hang
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [recipeData]);
 
   return (

--- a/content/components/pages/RecipeFormPage.tsx
+++ b/content/components/pages/RecipeFormPage.tsx
@@ -53,6 +53,8 @@ const RecipeFormPage: React.FC = () => {
       setData(INITIAL_RECIPE_DATA);
       setImportInstructions("");
     }
+    // XXX adding normandyApi or experimenterApi here causes the tests to hang
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [recipeId, experimenterSlug, environmentKey]);
 
   return (

--- a/content/components/pages/RecipesPage.tsx
+++ b/content/components/pages/RecipesPage.tsx
@@ -59,7 +59,7 @@ const RecipesPage: React.FC<RecipesPageProps> = ({
       setCount(data.count);
       setLoading(false);
     })();
-  }, [environmentKey, connectionStatus, recipeQuery]);
+  }, [environmentKey, connectionStatus, recipeQuery, api]);
 
   function copyRecipeToArbitrary(v3Recipe): void {
     const v1Recipe = convertToV1Recipe(

--- a/content/components/recipes/details/DetailsHeader.js
+++ b/content/components/recipes/details/DetailsHeader.js
@@ -150,8 +150,9 @@ export default function DetailsHeader() {
   }
 
   let telemetryLink = null;
+  const experimentData = useExperimenterDetailsData();
   if (environment.experimenterUrl && data.experimenter_slug) {
-    telemetryLink = <TelemetryLink {...useExperimenterDetailsData()} />;
+    telemetryLink = <TelemetryLink {...experimentData} />;
   }
 
   let requestApprovalButton = null;

--- a/content/components/recipes/details/RecipeQueryEditor.tsx
+++ b/content/components/recipes/details/RecipeQueryEditor.tsx
@@ -50,6 +50,9 @@ const RecipeQueryEditor: React.FC<Props> = ({
     setDraftQuery(
       query ?? getRecipeQueryFromUrlSearch(history.location.search),
     );
+    // This is used for an initial sync, and the next hook handles the ongoing
+    // updates when history.location changes.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [query]);
 
   // As the draft query changes, sync it into the URL
@@ -68,7 +71,7 @@ const RecipeQueryEditor: React.FC<Props> = ({
     const target =
       history.location.pathname + workUrl.search + history.location.hash;
     history.replace(target);
-  }, [draftQuery]);
+  }, [draftQuery, history]);
 
   // Respond to changes of query parameters in the url
   useEffect(() => {
@@ -83,7 +86,7 @@ const RecipeQueryEditor: React.FC<Props> = ({
     if (hasChanges) {
       setDraftQuery(newQuery);
     }
-  }, [history.location.search]);
+  }, [draftQuery, history.location.search]);
 
   // Handle changes to the fields
   function makeHandler(name: keyof RecipeListQuery, { debounce = true } = {}) {

--- a/content/components/recipes/details/SuitabilityTag.tsx
+++ b/content/components/recipes/details/SuitabilityTag.tsx
@@ -95,9 +95,9 @@ const SuitabilityTag: React.FC<SuitabilityTagProps> = ({
 }) => {
   const [suitabilities, setSuitabilities] = React.useState([]);
   const [loading, setLoading] = React.useState(true);
+  const recipeDetailsState = useRecipeDetailsState();
 
   if (!revision) {
-    const recipeDetailsState = useRecipeDetailsState();
     revision = recipeDetailsState.statusData;
   }
 

--- a/content/components/recipes/details/arguments/MultiPreferenceExperiment.js
+++ b/content/components/recipes/details/arguments/MultiPreferenceExperiment.js
@@ -15,6 +15,8 @@ import { useBranchTestingIds } from "devtools/hooks/testingIds";
 export default function MultiPreferenceExperiment({ data }) {
   let branchTestingIds;
   if (__ENV__ === "extension") {
+    // __ENV__ conditions are build-time, not run-time, so are safe
+    // eslint-disable-next-line react-hooks/rules-of-hooks
     branchTestingIds = useBranchTestingIds(data);
   }
 

--- a/content/components/recipes/details/filters/TestingClientId.tsx
+++ b/content/components/recipes/details/filters/TestingClientId.tsx
@@ -62,7 +62,7 @@ function useTestingId(filter: SampleFilterObject): AsyncHook<string> {
         setError(err);
         setLoading(false);
       });
-  }, []);
+  }, [filter]);
 
   if (error) {
     return { value: null, loading: false, error };

--- a/content/components/recipes/form/arguments/BranchedAddon.js
+++ b/content/components/recipes/form/arguments/BranchedAddon.js
@@ -62,7 +62,7 @@ function Branches() {
     normandyApi.fetchAllExtensions().then((allExtensions) => {
       setExtensions(allExtensions);
     });
-  }, [environmentKey]);
+  }, [environmentKey, normandyApi]);
 
   const extensionOptions = extensions.map((extension) => ({
     label: extension.name,

--- a/content/components/recipes/form/arguments/MultiPreferenceBranches.js
+++ b/content/components/recipes/form/arguments/MultiPreferenceBranches.js
@@ -79,7 +79,7 @@ function Branch({ index }) {
       });
       setPreferences(all_preferences);
     }
-  }, []);
+  }, [branch.preferences]);
 
   const handleClickAddPref = () => {
     const newPref = {

--- a/content/components/recipes/form/arguments/OptOutStudy.js
+++ b/content/components/recipes/form/arguments/OptOutStudy.js
@@ -19,7 +19,7 @@ export default function OptOutStudy() {
     normandyApi.fetchAllExtensions().then((allExtensions) => {
       setExtensions(allExtensions);
     });
-  }, [environmentKey]);
+  }, [environmentKey, normandyApi]);
 
   const options = extensions.map((extension) => ({
     label: extension.name,
@@ -62,7 +62,7 @@ export default function OptOutStudy() {
             options={options}
           />
           <ToggleField label="Prevent New Enrollment" name="isEnrollmentPaused">
-            Prevents new users from joining this study cohort. Exisiting users
+            Prevents new users from joining this study cohort. Existing users
             will remain in the study.
           </ToggleField>
         </Col>

--- a/content/components/recipes/form/arguments/PreferenceRollback.tsx
+++ b/content/components/recipes/form/arguments/PreferenceRollback.tsx
@@ -17,6 +17,8 @@ export default function PreferenceRollback(): ReactElement {
       .then((allRollouts) => {
         setRollouts(allRollouts);
       });
+    // XXX adding normandyApi here makes the tests never finish
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [environmentKey]);
 
   const rolloutData: Array<{

--- a/content/components/recipes/form/filters/GeoOptions.js
+++ b/content/components/recipes/form/filters/GeoOptions.js
@@ -24,7 +24,7 @@ export default function GeoOptions() {
     normandyApi.fetchFilters().then((filters) => {
       setFilters(filters);
     });
-  }, [environmentKey]);
+  }, [environmentKey, normandyApi]);
 
   return (
     <Row>

--- a/content/components/recipes/form/filters/SamplingOptions.tsx
+++ b/content/components/recipes/form/filters/SamplingOptions.tsx
@@ -40,7 +40,7 @@ const SamplingOptions: React.FC = () => {
   const data = useRecipeDetailsData();
   const dispatch = useRecipeDetailsDispatch();
 
-  const filterObject = getFilterObjectFromData();
+  const filterObject = useFilterObjectFromData();
   const typeValue = filterObject ? filterObject.type : null;
 
   const handleTypeChange = (value): void => {
@@ -129,7 +129,7 @@ interface Changeable {
 }
 
 const BucketSampleOptions: React.FC<Changeable> = ({ onChange }) => {
-  const filterObject = getFilterObjectFromData();
+  const filterObject = useFilterObjectFromData();
   assert(filterObject.type === BUCKET_SAMPLE);
   const input = filterObject.input || [];
 
@@ -152,7 +152,7 @@ const BucketSampleOptions: React.FC<Changeable> = ({ onChange }) => {
 };
 
 const StableSampleOptions: React.FC<Changeable> = ({ onChange }) => {
-  const filterObject = getFilterObjectFromData();
+  const filterObject = useFilterObjectFromData();
   assert(filterObject.type === STABLE_SAMPLE);
   const input = filterObject.input || [];
 
@@ -174,7 +174,7 @@ const StableSampleOptions: React.FC<Changeable> = ({ onChange }) => {
 };
 
 const NamespaceSampleOptions: React.FC<Changeable> = ({ onChange }) => {
-  const filterObject = getFilterObjectFromData();
+  const filterObject = useFilterObjectFromData();
   assert(filterObject.type === NAMESPACE_SAMPLE);
 
   return (
@@ -207,7 +207,7 @@ const SamplingNumberInput: React.FC<SamplingNumberInputProps> = ({
   onChange,
   isPercentage,
 }) => {
-  const filterObject = getFilterObjectFromData();
+  const filterObject = useFilterObjectFromData();
 
   let value = filterObject[name];
 
@@ -253,7 +253,7 @@ const SamplingNumberInput: React.FC<SamplingNumberInputProps> = ({
 };
 
 const SamplingInputInput: React.FC<Changeable> = ({ onChange }) => {
-  const filterObject = getFilterObjectFromData();
+  const filterObject = useFilterObjectFromData();
   assert(
     filterObject.type === STABLE_SAMPLE || filterObject.type === BUCKET_SAMPLE,
   );
@@ -298,7 +298,7 @@ const SamplingInputInput: React.FC<Changeable> = ({ onChange }) => {
 };
 
 const NamespaceInput: React.FC<Changeable> = ({ onChange }) => {
-  const filterObject = getFilterObjectFromData();
+  const filterObject = useFilterObjectFromData();
   assert(filterObject.type === NAMESPACE_SAMPLE);
 
   const value = filterObject.namespace;
@@ -328,7 +328,7 @@ type SamplingFilterObject =
   | StableSampleFilterObject
   | NamespaceSampleFilterObject;
 
-function getFilterObjectFromData(): SamplingFilterObject {
+function useFilterObjectFromData(): SamplingFilterObject {
   const data = useRecipeDetailsData();
 
   let filterObject;

--- a/content/hooks/testingIds.ts
+++ b/content/hooks/testingIds.ts
@@ -21,13 +21,6 @@ export function useBranchTestingIds(
       f.type === "namespaceSample" ||
       f.type === "stableSample",
   );
-  if (sampleFilters.length > 1) {
-    return {
-      loading: false,
-      value: null,
-      error: new Error("Found too many sample filter"),
-    };
-  }
 
   let filter = null;
   if (sampleFilters.length) {
@@ -44,6 +37,12 @@ export function useBranchTestingIds(
 
   useEffect(() => {
     (async (): Promise<void> => {
+      if (sampleFilters.length > 1) {
+        setLoading(false);
+        setBranchIds(null);
+        setError(new Error("Found too many sample filter"));
+      }
+
       if (
         !revision.filter_object.length ||
         !revision.arguments.branches?.length
@@ -77,7 +76,13 @@ export function useBranchTestingIds(
         setBranchIds(null);
       }
     })();
-  }, [revision.arguments?.branches, revision.filter_object]);
+  }, [
+    filter,
+    revision.arguments.branches,
+    revision.filter_object,
+    sampleFilters.length,
+    testingIdGenerator,
+  ]);
 
   if (error) {
     return { error, loading: false, value: null };

--- a/content/hooks/urls.ts
+++ b/content/hooks/urls.ts
@@ -10,6 +10,7 @@ export function useExtensionUrl(): URL {
 }
 
 export function useHistoryRecorder(): void {
+  /* eslint-disable react-hooks/rules-of-hooks */
   if (DEVELOPMENT) {
     const extensionUrl = useExtensionUrl();
     React.useEffect(() => {
@@ -19,4 +20,5 @@ export function useHistoryRecorder(): void {
       );
     }, [extensionUrl]);
   }
+  /* eslint-enable react-hooks/rules-of-hooks */
 }

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "eslint-plugin-no-unsanitized": "3.1.4",
     "eslint-plugin-prettier": "3.1.4",
     "eslint-plugin-react": "7.21.5",
+    "eslint-plugin-react-hooks": "^4.2.0",
     "extract-text-webpack-plugin": "3.0.2",
     "faker": "5.1.0",
     "file-loader": "6.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4845,6 +4845,11 @@ eslint-plugin-prettier@3.1.4:
   dependencies:
     prettier-linter-helpers "^1.0.0"
 
+eslint-plugin-react-hooks@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.2.0.tgz#8c229c268d468956334c943bb45fc860280f5556"
+  integrity sha512-623WEiZJqxR7VdxFCKLI6d6LLpwJkGPYKODnkH3D7WpOG5KM8yWueBd8TLsNAetEJNF5iJmolaAKO3F8yzyVBQ==
+
 eslint-plugin-react@7.21.5:
   version "7.21.5"
   resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.21.5.tgz#50b21a412b9574bfe05b21db176e8b7b3b15bff3"


### PR DESCRIPTION
This is a recommended-by-React part of using hooks that we haven't been doing. As such, there are a bunch of errors that showed up. Some of these were problems in practice, and showed up in the console during testing.

Some of the problems pointed out by the linter were false positives, because of our build-time invariants. Others didn't seem wrong to me, but fixing them the way the linter suggested broke our tests. I left comments on those, and maybe we can figure out why in the future.
