### PR TITLE
Make UI consistent and decluttering for details page

### DIFF
--- a/content/components/recipes/details/ActionDetails.tsx
+++ b/content/components/recipes/details/ActionDetails.tsx
@@ -1,6 +1,5 @@
-import PropTypes from "prop-types";
 import React from "react";
-import { ButtonGroup, Icon, IconButton, Popover, Tag, Whisper } from "rsuite";
+import { ButtonGroup, Icon, IconButton, Tag } from "rsuite";
 
 import Highlight from "devtools/components/common/Highlight";
 import AddonStudy from "devtools/components/recipes/details/arguments/AddonStudy";
@@ -10,7 +9,9 @@ import MessagingExperiment from "devtools/components/recipes/details/arguments/M
 import MultiPreferenceExperiment from "devtools/components/recipes/details/arguments/MultiPreferenceExperiment";
 import PreferenceExperiment from "devtools/components/recipes/details/arguments/PreferenceExperiment";
 import PreferenceRollout from "devtools/components/recipes/details/arguments/PreferenceRollout";
-import CollapsibleSection from "devtools/components/recipes/details/CollapsibleSection";
+import CollapsibleSection, {
+  HeaderButtonPopover,
+} from "devtools/components/recipes/details/CollapsibleSection";
 import { useRecipeDetailsData } from "devtools/contexts/recipeDetails";
 
 const MODE_RICH = "RICH";
@@ -26,7 +27,7 @@ const ACTION_DETAILS_MAPPING = {
   "preference-rollout": PreferenceRollout,
 };
 
-export default function ActionDetails() {
+const ActionDetails: React.FC = () => {
   const data = useRecipeDetailsData();
   const [mode, setMode] = React.useState(MODE_RICH);
 
@@ -52,20 +53,20 @@ export default function ActionDetails() {
     <CollapsibleSection
       headerButtons={
         <ButtonGroup>
-          <ModePopover message="Display the rich details">
+          <HeaderButtonPopover message="Display the rich details">
             <IconButton
               active={mode === MODE_RICH}
               icon={<Icon icon="file-text-o" />}
               onClick={generateHandlerModeClick(MODE_RICH)}
             />
-          </ModePopover>
-          <ModePopover message="Display the raw details">
+          </HeaderButtonPopover>
+          <HeaderButtonPopover message="Display the raw details">
             <IconButton
               active={mode === MODE_RAW}
               icon={<Icon icon="code" />}
               onClick={generateHandlerModeClick(MODE_RAW)}
             />
-          </ModePopover>
+          </HeaderButtonPopover>
         </ButtonGroup>
       }
       title={
@@ -82,24 +83,9 @@ export default function ActionDetails() {
       </div>
     </CollapsibleSection>
   );
-}
-
-function ModePopover({ children, message }) {
-  const popover = <Popover>{message}</Popover>;
-
-  return (
-    <Whisper placement="autoVerticalEnd" speaker={popover} trigger="hover">
-      {children}
-    </Whisper>
-  );
-}
-
-ModePopover.propTypes = {
-  children: PropTypes.any,
-  message: PropTypes.string,
 };
 
-function RawDetails() {
+const RawDetails: React.FC = () => {
   const data = useRecipeDetailsData();
 
   return (
@@ -109,4 +95,6 @@ function RawDetails() {
       </Highlight>
     </div>
   );
-}
+};
+
+export default ActionDetails;

--- a/content/components/recipes/details/ApprovalRequest.tsx
+++ b/content/components/recipes/details/ApprovalRequest.tsx
@@ -138,17 +138,23 @@ const ApprovalRequest: React.FC = () => {
       <>
         <div className="d-flex mt-4">
           <strong className="w-120px">Requested by:</strong>
-          <div className="flex-grow-1">{approvalRequest.creator.email}</div>
+          <div className="flex-grow-1 text-subtle">
+            {approvalRequest.creator.email}
+          </div>
         </div>
         <div className="d-flex mt-1">
           <strong className="w-120px">
             {approvalRequest.approved ? "Approved" : "Rejected"} by:
           </strong>
-          <div className="flex-grow-1">{approvalRequest.approver.email}</div>
+          <div className="flex-grow-1 text-subtle">
+            {approvalRequest.approver.email}
+          </div>
         </div>
         <div className="d-flex mt-1">
           <strong className="w-120px">Comment:</strong>
-          <div className="flex-grow-1">{approvalRequest.comment}</div>
+          <div className="flex-grow-1 text-subtle">
+            {approvalRequest.comment}
+          </div>
         </div>
       </>
     );
@@ -157,7 +163,7 @@ const ApprovalRequest: React.FC = () => {
   return (
     <>
       <CollapsibleSection
-        collapsed
+        collapsed={approvalRequest.approved !== null}
         testId="collapse-approval-request"
         title={
           <>

--- a/content/components/recipes/details/CollapsibleSection.tsx
+++ b/content/components/recipes/details/CollapsibleSection.tsx
@@ -1,17 +1,23 @@
 import React, { ReactElement } from "react";
-import { Icon, IconButton } from "rsuite";
+import { Icon, IconButton, Popover, Whisper } from "rsuite";
 
 interface CollapsibleSectionProps {
   headerButtons?: ReactElement;
+  showHeaderButtonsCollapsed?: boolean;
   collapsed?: boolean;
   title: ReactElement;
   testId?: string;
+}
+
+interface HeaderButtonPopoverProps {
+  message: string;
 }
 
 // default export
 const CollapsibleSection: React.FC<CollapsibleSectionProps> = ({
   children,
   headerButtons,
+  showHeaderButtonsCollapsed = false,
   title,
   collapsed: defaultCollapsed = false,
   testId = null,
@@ -39,14 +45,25 @@ const CollapsibleSection: React.FC<CollapsibleSectionProps> = ({
           </div>
           {title}
         </div>
-        {headerButtons && !collapsed && (
-          <div style={{ visibility: collapsed ? "hidden" : "visible" }}>
-            {headerButtons}
-          </div>
+        {headerButtons && (!collapsed || showHeaderButtonsCollapsed) && (
+          <div>{headerButtons}</div>
         )}
       </div>
       {collapsed ? null : children}
     </>
+  );
+};
+
+export const HeaderButtonPopover: React.FC<HeaderButtonPopoverProps> = ({
+  children,
+  message,
+}) => {
+  const popover = <Popover>{message}</Popover>;
+
+  return (
+    <Whisper placement="autoVerticalEnd" speaker={popover} trigger="hover">
+      {children}
+    </Whisper>
   );
 };
 

--- a/content/components/recipes/details/ExperimenterDetails.tsx
+++ b/content/components/recipes/details/ExperimenterDetails.tsx
@@ -1,26 +1,55 @@
 import React from "react";
+import { Divider, Icon, IconButton } from "rsuite";
 
-import CollapsibleSection from "devtools/components/recipes/details/CollapsibleSection";
+import CollapsibleSection, {
+  HeaderButtonPopover,
+} from "devtools/components/recipes/details/CollapsibleSection";
+import TelemetryLink from "devtools/components/recipes/details/TelemetryLink";
+import { useSelectedEnvironmentState } from "devtools/contexts/environment";
 import { useExperimenterDetailsData } from "devtools/contexts/experimenterDetails";
+import { useRecipeDetailsData } from "devtools/contexts/recipeDetails";
 
 const ExperimenterDetails: React.FunctionComponent = () => {
   const data = useExperimenterDetailsData();
+  const recipeData = useRecipeDetailsData();
+  const { environment } = useSelectedEnvironmentState();
+
+  if (!data || Object.keys(data).length === 0) {
+    return null;
+  }
+
   return (
-    <CollapsibleSection
-      headerButtons={<></>}
-      title={<h6>Experimenter Details</h6>}
-    >
-      <div className="py-1 pl-4">
-        {data && Object.keys(data).length ? (
+    <>
+      <CollapsibleSection
+        showHeaderButtonsCollapsed
+        headerButtons={
+          <>
+            <HeaderButtonPopover message="View in Experimenter">
+              <IconButton
+                className="mr-1"
+                componentClass="a"
+                href={`${environment.experimenterUrl}experiments/${recipeData.experimenter_slug}`}
+                icon={<Icon icon="external-link" />}
+                target="_blank"
+              />
+            </HeaderButtonPopover>
+            <HeaderButtonPopover message="View Telemetry">
+              <TelemetryLink {...data} />
+            </HeaderButtonPopover>
+          </>
+        }
+        title={<h6>Experimenter Details</h6>}
+      >
+        <div className="py-1 pl-4">
           <div className="d-flex w-100">
             <div className="flex-basis-0 flex-grow-1">
               <div className="mt-4 mr-2">
                 <strong>Public description</strong>
-                <p>{data.publicDescription}</p>
+                <p className="text-subtle my-1">{data.publicDescription}</p>
               </div>
               <div className="mt-4" data-testid="details-proposed-schedule">
                 <strong>Proposed schedule</strong>
-                <p>
+                <p className="text-subtle my-1">
                   {data.proposedStartDate?.toDateString()} →{" "}
                   {data.proposedEndDate?.toDateString()} (
                   {data.proposedDuration} days)
@@ -28,7 +57,7 @@ const ExperimenterDetails: React.FunctionComponent = () => {
               </div>
               <div className="mt-4">
                 <strong>Actual Schedule</strong>
-                <p>
+                <p className="text-subtle my-1">
                   {data.startDate?.toDateString() ?? "N/A"}
                   {data.endDate ? " → " + data.endDate.toDateString() : ""}
                 </p>
@@ -52,11 +81,22 @@ const ExperimenterDetails: React.FunctionComponent = () => {
               ) : null}
             </div>
           </div>
-        ) : (
-          <p>N/A</p>
-        )}
-      </div>
-    </CollapsibleSection>
+          <div className="mt-4">
+            <IconButton
+              className="mr-1"
+              componentClass="a"
+              href={`${environment.experimenterUrl}experiments/${recipeData.experimenter_slug}`}
+              icon={<Icon icon="external-link" />}
+              target="_blank"
+            >
+              View in Experimenter
+            </IconButton>
+            <TelemetryLink {...data}>View Telemetry</TelemetryLink>
+          </div>
+        </div>
+      </CollapsibleSection>
+      <Divider />
+    </>
   );
 };
 

--- a/content/components/recipes/details/ExperimenterDetails.tsx
+++ b/content/components/recipes/details/ExperimenterDetails.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Divider, Icon, IconButton } from "rsuite";
+import { Divider, Icon, IconButton, Tag } from "rsuite";
 
 import CollapsibleSection, {
   HeaderButtonPopover,
@@ -67,12 +67,14 @@ const ExperimenterDetails: React.FunctionComponent = () => {
               {Object.keys(data.variants).length ? (
                 <div className="mt-4">
                   <strong>Branches</strong>
-                  <dl>
+                  <dl className="mt-1">
                     {Object.entries(data.variants).map(
                       ([slug, description]) => (
                         <>
-                          <dt>{slug}</dt>
-                          <dd>{description}</dd>
+                          <dt className="mt-2">
+                            <Tag>{slug}</Tag>
+                          </dt>
+                          <dd className="mt-1 text-subtle">{description}</dd>
                         </>
                       ),
                     )}

--- a/content/components/recipes/details/FilteringDetails.tsx
+++ b/content/components/recipes/details/FilteringDetails.tsx
@@ -1,9 +1,10 @@
-import PropTypes from "prop-types";
 import React from "react";
-import { ButtonGroup, Icon, IconButton, Popover, Whisper } from "rsuite";
+import { ButtonGroup, Icon, IconButton } from "rsuite";
 
 import Highlight from "devtools/components/common/Highlight";
-import CollapsibleSection from "devtools/components/recipes/details/CollapsibleSection";
+import CollapsibleSection, {
+  HeaderButtonPopover,
+} from "devtools/components/recipes/details/CollapsibleSection";
 import BucketSample from "devtools/components/recipes/details/filters/BucketSample";
 import Channel from "devtools/components/recipes/details/filters/Channel";
 import Country from "devtools/components/recipes/details/filters/Country";
@@ -28,7 +29,7 @@ const FILTER_OBJECT_MAPPING = {
   namespaceSample: NamespaceSample,
 };
 
-export default function FilteringDetails() {
+const FilteringDetails: React.FC = () => {
   const data = useRecipeDetailsData();
   const [mode, setMode] = React.useState(MODE_RICH);
 
@@ -77,27 +78,27 @@ export default function FilteringDetails() {
     <CollapsibleSection
       headerButtons={
         <ButtonGroup>
-          <ModePopover message="Display the rich details">
+          <HeaderButtonPopover message="Display the rich details">
             <IconButton
               active={mode === MODE_RICH}
               icon={<Icon icon="file-text-o" />}
               onClick={generateHandlerModeClick(MODE_RICH)}
             />
-          </ModePopover>
-          <ModePopover message="Display the composite details">
+          </HeaderButtonPopover>
+          <HeaderButtonPopover message="Display the composite details">
             <IconButton
               active={mode === MODE_COMPOSITE}
               icon={<Icon icon="cubes" />}
               onClick={generateHandlerModeClick(MODE_COMPOSITE)}
             />
-          </ModePopover>
-          <ModePopover message="Display the raw details">
+          </HeaderButtonPopover>
+          <HeaderButtonPopover message="Display the raw details">
             <IconButton
               active={mode === MODE_RAW}
               icon={<Icon icon="code" />}
               onClick={generateHandlerModeClick(MODE_RAW)}
             />
-          </ModePopover>
+          </HeaderButtonPopover>
         </ButtonGroup>
       }
       title={<h6 className="flex-grow-1">Filtering</h6>}
@@ -108,24 +109,9 @@ export default function FilteringDetails() {
       </div>
     </CollapsibleSection>
   );
-}
-
-function ModePopover({ children, message }) {
-  const popover = <Popover>{message}</Popover>;
-
-  return (
-    <Whisper placement="autoVerticalEnd" speaker={popover} trigger="hover">
-      {children}
-    </Whisper>
-  );
-}
-
-ModePopover.propTypes = {
-  children: PropTypes.any,
-  message: PropTypes.string,
 };
 
-function RawDetails() {
+const RawDetails: React.FC = () => {
   const data = useRecipeDetailsData();
 
   return (
@@ -136,9 +122,9 @@ function RawDetails() {
       </Highlight>
     </div>
   );
-}
+};
 
-function RichDetails() {
+const RichDetails: React.FC = () => {
   const { filter_object: filterObjects, recipe } = useRecipeDetailsData();
 
   return filterObjects
@@ -178,4 +164,6 @@ function RichDetails() {
         </div>
       );
     });
-}
+};
+
+export default FilteringDetails;

--- a/content/components/recipes/details/RecipeDetails.tsx
+++ b/content/components/recipes/details/RecipeDetails.tsx
@@ -38,9 +38,8 @@ const RecipeDetails: React.FunctionComponent = () => {
         </div>
       </div>
       <Divider />
-      <ExperimenterDetails />
-      <Divider />
       <ApprovalRequest />
+      <ExperimenterDetails />
       <ActionDetails />
       <Divider />
       <FilteringDetails />

--- a/content/components/recipes/details/TelemetryLink.tsx
+++ b/content/components/recipes/details/TelemetryLink.tsx
@@ -1,6 +1,9 @@
 import React from "react";
-import { Icon, IconButton, Nav } from "rsuite";
+import { Icon } from "rsuite";
 import { TypeAttributes as RSTypeAttributes } from "rsuite/lib/@types/common";
+// Import the follow to deal with https://github.com/istanbuljs/babel-plugin-istanbul/issues/258
+import IconButton from "rsuite/lib/IconButton";
+import Nav from "rsuite/lib/Nav";
 
 const MONITORING_URL = "https://grafana.telemetry.mozilla.org";
 const DASHBOARD_ID = "XspgvdxZz";

--- a/content/components/recipes/details/TelemetryLink.tsx
+++ b/content/components/recipes/details/TelemetryLink.tsx
@@ -1,17 +1,32 @@
 import React from "react";
-import { Icon, IconButton } from "rsuite";
+import { Icon, IconButton, Nav } from "rsuite";
+import { TypeAttributes as RSTypeAttributes } from "rsuite/lib/@types/common";
 
 const MONITORING_URL = "https://grafana.telemetry.mozilla.org";
 const DASHBOARD_ID = "XspgvdxZz";
 
+export enum TelemetryLinkTypes {
+  iconButton,
+  navItem,
+}
+
 interface TelemetryLinkProps {
+  type?: TelemetryLinkTypes;
   endDate?: Date;
   normandySlug: string;
   startDate?: Date;
   status: string;
+  appearance?: RSTypeAttributes.Appearance;
+}
+
+interface TelemetryLinkExtraProps {
+  icon?: React.ReactElement;
 }
 
 const TelemetryLink: React.FC<TelemetryLinkProps> = ({
+  appearance = "default",
+  children,
+  type = TelemetryLinkTypes.iconButton,
   startDate,
   endDate,
   normandySlug,
@@ -28,17 +43,26 @@ const TelemetryLink: React.FC<TelemetryLinkProps> = ({
     to = `${endDate.getTime() + 2 * 24 * 3600 * 1000}`;
   }
 
+  let Component = IconButton;
+  let extraProps: TelemetryLinkExtraProps = {
+    icon: <Icon icon="bar-chart" />,
+  };
+  if (type === TelemetryLinkTypes.navItem) {
+    Component = Nav.Item;
+    extraProps = {};
+  }
+
   const url = `${MONITORING_URL}/d/${DASHBOARD_ID}/experiment-enrollment?orgId=1&var-experiment_id=${normandySlug}&from=${from}&to=${to}`;
   return (
-    <IconButton
-      appearance="subtle"
+    <Component
+      appearance={appearance}
       componentClass="a"
       href={url}
-      icon={<Icon icon="external-link" />}
       target="_blank"
+      {...extraProps}
     >
-      View Telemetry
-    </IconButton>
+      {children}
+    </Component>
   );
 };
 

--- a/content/tests/components/recipes/details/RecipeDetails.test.js
+++ b/content/tests/components/recipes/details/RecipeDetails.test.js
@@ -225,8 +225,6 @@ describe("The `RecipeDetails` component", () => {
     await doc.findByText(recipeData.latest_revision.name);
     expect(doc.getByText("Approval Request")).toBeInTheDocument();
 
-    const expandApproval = await doc.findByTestId("collapse-approval-request");
-    fireEvent.click(expandApproval);
     expect(doc.getByText("Comment:")).toBeInTheDocument();
 
     const comment = document.querySelector("input");
@@ -252,8 +250,6 @@ describe("The `RecipeDetails` component", () => {
     await doc.findByText(recipeData.latest_revision.name);
     expect(doc.getByText("Approval Request")).toBeInTheDocument();
 
-    const expandApproval = await doc.findByTestId("collapse-approval-request");
-    fireEvent.click(expandApproval);
     expect(doc.getByText("Comment:")).toBeInTheDocument();
 
     const comment = document.querySelector("input");
@@ -279,8 +275,6 @@ describe("The `RecipeDetails` component", () => {
     await doc.findByText(recipeData.latest_revision.name);
     expect(doc.getByText("Approval Request")).toBeInTheDocument();
 
-    const expandApproval = await doc.findByTestId("collapse-approval-request");
-    fireEvent.click(expandApproval);
     expect(doc.getByText("Comment:")).toBeInTheDocument();
 
     fireEvent.click(doc.getByText("Cancel Request"));


### PR DESCRIPTION
this PR does a few things:
- corrects some visual inconsistencies on the details page
  - add subtle text color to field values in approval request and experimenter section
  - fix some margins
- re-orders experimenter details section and approval request section
- declutters the recipe details page header by moving the experimenter and telemetry links
  - links are now in the menu under the ellipsis button
  - links also in the header of experimenter details section
  - links also in the panel of the experimenter details section
- converts a few more `.js` files to `.tsx`

r?