### PR TITLE
Make some acronyms render better in automatic labels

### DIFF
--- a/content/tests/utils/helpers.test.ts
+++ b/content/tests/utils/helpers.test.ts
@@ -24,6 +24,18 @@ describe("splitCamelCase", () => {
     it("should handle a final letter", () => {
       expect(splitCamelCase("getX")).toEqual("get x");
     });
+
+    it("should have special cases for some acronyms", () => {
+      expect(splitCamelCase("experimentDocumentUrl")).toEqual(
+        "experiment document URL",
+      );
+      expect(splitCamelCase("extensionApiId")).toEqual("extension API ID");
+
+      // it shouldn't be too eager and replace those acronyms inside words
+      expect(splitCamelCase("curlLidMegapixels")).toEqual(
+        "curl lid megapixels",
+      );
+    });
   });
 
   describe("case: title-case", () => {
@@ -47,6 +59,20 @@ describe("splitCamelCase", () => {
 
     it("should handle a final letter", () => {
       expect(splitCamelCase("getX", { case: "title-case" })).toEqual("Get X");
+    });
+
+    it("should have special cases for some acronyms", () => {
+      expect(
+        splitCamelCase("experimentDocumentUrl", { case: "title-case" }),
+      ).toEqual("Experiment Document URL");
+      expect(splitCamelCase("extensionApiId", { case: "title-case" })).toEqual(
+        "Extension API ID",
+      );
+
+      // it shouldn't be too eager though
+      expect(
+        splitCamelCase("curlLidMegapixels", { case: "title-case" }),
+      ).toEqual("Curl Lid Megapixels");
     });
   });
 });

--- a/content/utils/helpers.ts
+++ b/content/utils/helpers.ts
@@ -16,7 +16,7 @@ export function splitCamelCase(
       return group1 + " " + group2.toLowerCase();
     })
 
-    // A normal camel case transition, with a single capital letter lase
+    // A normal camel case transition, with a single capital letter
     .replace(/([a-z])([A-Z].)/g, (match, group1: string, group2: string) => {
       if (group2 === group2.toUpperCase()) {
         return group1 + " " + group2;
@@ -39,6 +39,9 @@ export function splitCamelCase(
       (_, match1, match2) => match1 + match2.toUpperCase(),
     );
   }
+
+  // Special case a few acronyms
+  rv = rv.replace(/\b(url|api|id)\b/gi, (acronym) => acronym.toUpperCase());
 
   return rv;
 }


### PR DESCRIPTION
This is entirely cosmetic, but it's something that has bugged me for a while. This fixes the cases I know about, but maybe there are others we should add to the list?
