### PR TITLE
Make console.warn and console.error throw an error for new tests

### DIFF
--- a/content/tests/.eslintrc.js
+++ b/content/tests/.eslintrc.js
@@ -1,6 +1,8 @@
 module.exports = {
   globals: {
     renderWithContext: false,
+    restoreConsole: false,
+    modifyConsole: false,
   },
   env: {
     node: true,

--- a/content/tests/AppHeader.test.js
+++ b/content/tests/AppHeader.test.js
@@ -18,6 +18,14 @@ function WrappedAppHeader() {
 }
 
 describe("`AppHeader`", () => {
+  beforeEach(() => {
+    restoreConsole();
+  });
+
+  afterEach(() => {
+    modifyConsole();
+  });
+
   it("should start the authentication flow when the login button is clicked", async () => {
     const spyLaunchWebAuthFlow = jest.spyOn(
       browser.identity,

--- a/content/tests/RecipeForm.test.js
+++ b/content/tests/RecipeForm.test.js
@@ -22,9 +22,14 @@ import ExperimenterAPI from "devtools/utils/experimenterApi";
 import NormandyAPI from "devtools/utils/normandyApi";
 
 describe("The `RecipeForm` component", () => {
+  beforeEach(() => {
+    restoreConsole();
+  });
+
   afterEach(async () => {
     await jest.clearAllMocks();
     await cleanup();
+    modifyConsole();
   });
 
   const findForm = (formGroups, formName) => {

--- a/content/tests/components/common/ActionSelector.test.tsx
+++ b/content/tests/components/common/ActionSelector.test.tsx
@@ -11,12 +11,14 @@ describe("ActionSelector", () => {
   const api = new NormandyAPI(environmentFactory.build(), null, false);
 
   beforeEach(() => {
+    restoreConsole();
     jest
       .spyOn(NormandyAPI.prototype, "fetchAllActions")
       .mockResolvedValue(actions);
   });
 
   afterEach(() => {
+    modifyConsole();
     jest.clearAllMocks();
     cleanup();
   });

--- a/content/tests/components/pages/ExtensionPage.test.tsx
+++ b/content/tests/components/pages/ExtensionPage.test.tsx
@@ -29,12 +29,15 @@ beforeEach(() => {
         results: extensionPage,
       };
     });
+
+  restoreConsole();
 });
 
 afterEach(() => {
   jest.clearAllMocks();
   jest.clearAllTimers();
   cleanup();
+  modifyConsole();
 });
 
 describe("ExtensionPage", () => {

--- a/content/tests/components/pages/OverviewPage.test.tsx
+++ b/content/tests/components/pages/OverviewPage.test.tsx
@@ -15,7 +15,12 @@ import { RecipeV3 } from "devtools/types/recipes";
 import ExperimenterAPI from "devtools/utils/experimenterApi";
 import NormandyAPI from "devtools/utils/normandyApi";
 
+beforeEach(() => {
+  restoreConsole();
+});
+
 afterEach(async () => {
+  modifyConsole();
   jest.clearAllMocks();
   await cleanup();
 });

--- a/content/tests/components/recipes/RecipeListing.test.tsx
+++ b/content/tests/components/recipes/RecipeListing.test.tsx
@@ -13,7 +13,13 @@ declare global {
     }
   }
 }
+
+beforeEach(() => {
+  restoreConsole();
+});
+
 afterEach(async () => {
+  modifyConsole();
   jest.clearAllMocks();
   await cleanup();
 });

--- a/content/tests/components/recipes/details/RecipeDetails.test.js
+++ b/content/tests/components/recipes/details/RecipeDetails.test.js
@@ -34,7 +34,12 @@ function renderForTest(recipe, component = <RecipeDetailsPage />) {
 }
 
 describe("The `RecipeDetails` component", () => {
+  beforeEach(() => {
+    restoreConsole();
+  });
+
   afterEach(async () => {
+    modifyConsole();
     jest.clearAllMocks();
     await cleanup();
   });

--- a/content/tests/components/recipes/form/arguments/PreferenceRollback.test.tsx
+++ b/content/tests/components/recipes/form/arguments/PreferenceRollback.test.tsx
@@ -8,7 +8,12 @@ import { PreferenceRolloutArguments } from "devtools/types/arguments";
 import { RecipeV3 } from "devtools/types/recipes";
 import NormandyAPI from "devtools/utils/normandyApi";
 
+beforeEach(() => {
+  restoreConsole();
+});
+
 afterEach(async () => {
+  modifyConsole();
   jest.clearAllMocks();
   await cleanup();
 });

--- a/content/tests/components/recipes/listings/RecipeQueryEditor.test.tsx
+++ b/content/tests/components/recipes/listings/RecipeQueryEditor.test.tsx
@@ -17,6 +17,8 @@ describe("RecipeQueryEditor", () => {
   let api: NormandyAPI;
 
   beforeEach(() => {
+    restoreConsole();
+
     jest.useFakeTimers("modern");
     // use-debounce tries to use requestAnimationFrame if it is available,
     // requestAnimationFrame is not hooked by Jest's fake timers. Setting it to
@@ -29,6 +31,7 @@ describe("RecipeQueryEditor", () => {
   });
 
   afterEach(() => {
+    modifyConsole();
     jest.clearAllMocks();
     cleanup();
   });

--- a/content/tests/components/recipes/listings/RecipeQueryEditor.test.tsx
+++ b/content/tests/components/recipes/listings/RecipeQueryEditor.test.tsx
@@ -12,13 +12,19 @@ import { environmentFactory } from "devtools/tests/factories/state";
 import { Action } from "devtools/types/normandyApi";
 import NormandyAPI from "devtools/utils/normandyApi";
 
+beforeEach(() => {
+  restoreConsole();
+});
+
+afterEach(() => {
+  modifyConsole();
+});
+
 describe("RecipeQueryEditor", () => {
   let actions: Array<Action>;
   let api: NormandyAPI;
 
   beforeEach(() => {
-    restoreConsole();
-
     jest.useFakeTimers("modern");
     // use-debounce tries to use requestAnimationFrame if it is available,
     // requestAnimationFrame is not hooked by Jest's fake timers. Setting it to
@@ -31,7 +37,6 @@ describe("RecipeQueryEditor", () => {
   });
 
   afterEach(() => {
-    modifyConsole();
     jest.clearAllMocks();
     cleanup();
   });

--- a/content/tests/jest.setup.js
+++ b/content/tests/jest.setup.js
@@ -10,6 +10,31 @@ import { Router, Route } from "react-router-dom";
 
 import { EnvironmentProvider } from "devtools/contexts/environment";
 
+global.consoleWarn = console.warn;
+global.consoleError = console.error;
+
+// Prevent console.info from printing anything in results
+console.info = () => {};
+
+global.restoreConsole = () => {
+  console.warn = global.consoleWarn;
+  console.error = global.consoleError;
+};
+
+global.modifyConsole = () => {
+  console.warn = (...data) => {
+    global.consoleWarn(...data);
+    throw new Error("`console.warn` was called.");
+  };
+
+  console.error = (...data) => {
+    global.consoleError(...data);
+    throw new Error("`console.error` was called.");
+  };
+};
+
+modifyConsole();
+
 Object.defineProperty(global.self, "crypto", {
   value: {
     getRandomValues: (arr) => crypto.randomBytes(arr.length),

--- a/types/global/index.d.ts
+++ b/types/global/index.d.ts
@@ -11,6 +11,9 @@ declare const __ENV__: "web" | "extension";
 
 declare const __TESTING__: boolean;
 
+declare const restoreConsole: () => void;
+declare const modifyConsole: () => void;
+
 declare namespace browser.experiments.normandy {
   type V1Recipe = Record<string, unknown>;
 


### PR DESCRIPTION
Fix #534.

This is the stopgap solution we discussed to ensure new tests don't make these `console.warn` and `console.error` calls. It will allow us to slowly fix the existing tests and hopefully eventually totally clean up the output.

r?