### PR TITLE
Remove dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,0 @@
-version: 2
-updates:
-  - package-ecosystem: "npm"
-    directory: "/"
-    schedule:
-      interval: "daily"
-    # Disable rebasing, since it interferes with Bors
-    rebase-strategy: "disabled"
-


### PR DESCRIPTION
We don't need the latest libraries any more, since we aren't actively working on NDT. Github's Dependabot should still provide security updates, even without this config.